### PR TITLE
Normalize empty lines between entries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Table of contents
 
 Restrict the inclusion of a % character.
 
-|Admiral|
+.. image:: /screenshots/admiral.png
 
 
 `ADP <https://login.adp.nl/selfservice/private/passchange/#/>`__
@@ -38,7 +38,7 @@ Restrict the inclusion of a % character.
 Forced to change the password during the first login. At least they
 could use proper grammar in their rule list.
 
-|ADP|
+.. image:: /screenshots/adp.png
 
 
 `Advanzia <https://mein.advanzia.com/icc/assisto/nav/f96/f963b01b-043c-a21a-72e5-fd2ce0f2d5a2.htm#Sicherheit>`__
@@ -49,7 +49,7 @@ could use proper grammar in their rule list.
 - Allows only specific special characters: ? ! $ €% & * _ = - +. ,:; / () {} [] ~ @ #
 - Allows no spaces
 
-|Advanzia|
+.. image:: /screenshots/advanzia.png
 
 
 `Air Asia <https://www.airasia.com/member/>`__
@@ -58,7 +58,7 @@ could use proper grammar in their rule list.
 Only allows 16 characters in the password input, but does not tell you that.
 Why is your password invalid? It's up to you to find out!
 
-|Air Asia|
+.. image:: /screenshots/airaisa.png
 
 
 `Air France <https://www.airfrance.fr/>`__
@@ -67,7 +67,7 @@ Why is your password invalid? It's up to you to find out!
 - Between 8 to 12 characters
 - Should contain capital, lowercase letters and numbers
 
-|Air France|
+.. image:: /screenshots/airfrance.png
 
 
 `Aigües de Barcelona <https://www.aiguesdebarcelona.cat/oficinaenxarxa/>`__
@@ -76,7 +76,7 @@ Why is your password invalid? It's up to you to find out!
 - Between 6 to 10 characters
 - Only letters and numbers, without spaces
 
-|Aigues de Barcelona|
+.. image:: /screenshots/aigues_barcelona.png
 
 
 `American Express <https://sso.americanexpress.com/SSO/request?request_type=un_createid&ssolang=en_NL&inav=at_sitefooter_register>`__
@@ -84,7 +84,7 @@ Why is your password invalid? It's up to you to find out!
 
 Sometimes I forget that caps-lock is on, glad it doesn't matter.
 
-|American Express|
+.. image:: /screenshots/american-express.jpg
 
 
 `Ameli.fr (French national health insurance) <https://www.ameli.fr/>`__
@@ -99,7 +99,7 @@ This was very painful to find a password that works with this one and that I can
 - You cannot use a sequence of digits (if your password happens to contain 56 or 89 it will be rejected)
 - You cannot repeat the same character (if your password contains 22 or 55 it will be rejected)
 
-|ameli.fr|
+.. image:: /screenshots/ameli.fr.png
 
 
 `AmeriHealth <https://www.amerihealth.com/>`__
@@ -111,7 +111,7 @@ secure as you'd like.
     User Password must be between 6 and 14 characters and contain 1
     numerical value.
 
-|AmeriHealth|
+.. image:: /screenshots/amerihealth.png
 
 
 `AmiAmi <https://www.amiami.com/eng/>`__
@@ -119,7 +119,7 @@ secure as you'd like.
 
 Your password needs to be between 6 and 12 characters long, must contain only letters and numbers.
 
-|AmiAmi|
+.. image:: /screenshots/amiami.jpg
 
 
 `ANZ Bank <https://anz.com.au/>`__
@@ -127,7 +127,7 @@ Your password needs to be between 6 and 12 characters long, must contain only le
 
 Your password needs to be between 8 and 16 characters long - no special characters allowed.
 
-|ANZBank|
+.. image:: /screenshots/anz_bank.png
 
 
 `AOL <https://aol.com/>`__
@@ -135,7 +135,7 @@ Your password needs to be between 8 and 16 characters long - no special characte
 
 Between 8 and 16, so I can't go up to 20.
 
-|AOL|
+.. image:: /screenshots/aol.png
 
 
 `Apple <https://apple.com/>`__
@@ -143,8 +143,8 @@ Between 8 and 16, so I can't go up to 20.
 
 Can't contain 3 or more consecutive identical characters, nor can it be more than 32 characters long.
 
-|Apple1|
-|Apple2|
+.. image:: /screenshots/apple1.jpg
+.. image:: /screenshots/apple2.png
 
 
 `Arbeitnehmeronline <https://www.arbeitnehmeronline.de>`__
@@ -154,7 +154,7 @@ Service for managing employment documents of the German company Datev.
 
 Only the following character categories are allowed: Letters, numbers and this special charaters set: !#$%&()*+,-./:;<=>?@[\]^_`{|}~äöüßÄÖÜ
 
-|Arbeitnehmeronline|
+.. image:: /screenshots/arbeitnehmeronline.png
 
 
 `Arlo <https://arlo.netgear.com/?passwordResetCode>`__
@@ -163,7 +163,7 @@ Only the following character categories are allowed: Letters, numbers and this s
 Your password contains characters not listed. Therefore, they do not
 match.
 
-|Arlo|
+.. image:: /screenshots/arlo.png
 
 
 `ASN Bank <https://www.asnbank.nl/>`__
@@ -171,7 +171,7 @@ match.
 
 Your password needs to be between 8 and 20 characters long - at least 1 number, 1 lower case letter, 1 upper case letter, 1 special character.
 
-|asnbank|
+.. image:: /screenshots/asnbank.png
 
 
 `AT&T <https://www.att.com>`__
@@ -179,7 +179,7 @@ Your password needs to be between 8 and 20 characters long - at least 1 number, 
 
 The only special characters allowed are underscores and hyphens.
 
-|ATT|
+.. image:: /screenshots/att.png
 
 
 `Bank of America <https://secure.bankofamerica.com/auth/forgot/reset-entry/>`__
@@ -188,7 +188,7 @@ The only special characters allowed are underscores and hyphens.
 20 character max and lots of special character restrictions.
 Bank of America - keeping your money safe.
 
-|Bank of America|
+.. image:: /screenshots/boa.png
 
 
 `Banca Intesa Serbia <https://online.bancaintesa.rs/Retail/home/login>`__
@@ -201,7 +201,7 @@ characters is 22, minimum number of upper case letters is 1, lower case also 1,
 numeric characters is 2, first character must be a upper or lower case letter
 and maximum number of character repeats is 2.
 
-|Banca Intesa Serbia|
+.. image:: /screenshots/banca_intesa_serbia.png
 
 
 `Banco Mercantil <https://www.mercantilbanco.com/>`__
@@ -212,7 +212,7 @@ requires lowercase, uppercase, and numbers. Consecutive chars are
 prohibited. Did I mention the page hangs while you type? That eye icon
 tho.
 
-|Banco Mercantil|
+.. image:: /screenshots/banco-mercantil.png
 
 
 `Bank Millennium <https://www.bankmillennium.pl/osobiste2/Retail/Login/MulticodeRequest>`__
@@ -220,7 +220,7 @@ tho.
 
 Passwords limited to 8 digits.
 
-|Bank Millennium|
+.. image:: /screenshots/bank-millennium.png
 
 
 `Battle.net <https://eu.battle.net/account/creation/en-us/>`__
@@ -230,7 +230,7 @@ Passwords limited to 8 digits.
 
 A real time travel adventure through the password rules of 2005!
 
-|Battle.net|
+.. image:: /screenshots/battlenet.png
 
 
 `BBVA <https://web.bbva.es/public.html?v=20190510#public/hazte-cliente>`__
@@ -240,7 +240,7 @@ Username is your national ID (easy to find) and your password must have up to **
 
 For a bank account with all your money in one of the largest financial institutions in the world.
 
-|BBVA|
+.. image:: /screenshots/bbva.png
 
 
 `BCV <https://www.bcv.ch/>`__
@@ -250,8 +250,8 @@ Username is randomly generated, example: 'H2487414'. The password must have **6*
 
 Password can only be changed from the mobile application:
 
-|BCV Web|
-|BCV Mobile|
+.. image:: /screenshots/bcv_web.png
+.. image:: /screenshots/bcv_mobile_password.png
 
 
 `Bendigo Bank <https://banking.bendigobank.com.au/Logon/passwd.page>`__
@@ -259,7 +259,7 @@ Password can only be changed from the mobile application:
 
 **Exactly** eight characters.
 
-|Bendigo Bank|
+.. image:: /screenshots/bendigo_bank.png
 
 
 `BDO <https://www.bdo.com.ph/personal>`__
@@ -269,7 +269,7 @@ Please nominate a password which contains UPPERCASE, lowercase, numbers and symb
 Password should not be the same as the user ID.
 Avoid using consecutive characters such (ex. abc, DEF, 678) and invalid characters such as [!#$%^&';"].
 
-|BDO|
+.. image:: /screenshots/bdo.png
 
 
 `Best Buy <https://www-ssl.bestbuy.com/identity/changePassword>`__
@@ -289,7 +289,7 @@ login again.
 They force you to enter a password that has 8, 9, or 10 characters, then
 they lecture you on how to create a strong password.
 
-|Blackrock|
+.. image:: /screenshots/blackrock.png
 
 
 `Bloomingdale's <https://www.bloomingdales.com/account/createaccount?cm_sp=my_account-_-sign_in-_-create_account>`__
@@ -297,7 +297,7 @@ they lecture you on how to create a strong password.
 
 16 characters maximum, no ``.`` ``,`` ``-`` ``|`` ``/`` ``=`` or ``_`` allowed.
 
-|Bloomingdale's|
+.. image:: /screenshots/bloomingdales.png
 
 
 `Blue Cross Blue Shield Massachusetts <https://www.bluecrossma.com/wps/portal/register>`__
@@ -306,7 +306,7 @@ they lecture you on how to create a strong password.
 16 maximum and no special characters. Protecting your US healthcare
 information.
 
-|Blue Cross Blue Shield Massachusetts|
+.. image:: /screenshots/bcbs-massachusetts.png
 
 
 `BMO Bank of Montreal <https://www1.bmo.com/onlinebanking/cgi-bin/netbnx/NBmain?product=5>`__
@@ -314,7 +314,7 @@ information.
 
 Password requires at least one special character but disallows backtick `````, backslash ``\``, vertical bar ``|``, and underscore ``_``.
 
-|BMO Bank of Montreal|
+.. image:: /screenshots/bmo.jpg
 
 
 `BMW ConnectedDrive <https://www.bmw-connecteddrive.co.uk/>`__
@@ -324,7 +324,7 @@ Although the prompt suggests good things, after many failed attempts to
 set a new password, it turns out you can ONLY use the special characters
 shown in the prompt
 
-|BMW ConnectedDrive|
+.. image:: /screenshots/bmw-connected.PNG
 
 
 `Boligøen (Danish resident renting bureau) <https://boligøen.dk/>`__
@@ -332,7 +332,7 @@ shown in the prompt
 
 Red text: "Your password has to be at least 6 characters, but NOT over 20 characters."
 
-|Boligøen|
+.. image:: /screenshots/boligoen.jpg
 
 
 `Boursorama <https://www.boursorama.com/>`__
@@ -342,7 +342,7 @@ Red text: "Your password has to be at least 6 characters, but NOT over 20 charac
 have... 8 digits". And it must be entered using a funny keypad
 with the digits in the wrong order.
 
-|Boursorama|
+.. image:: /screenshots/boursorama.png
 
 
 `CAF (French Family Allowance Fund) <https://www.caf.fr/>`__
@@ -350,7 +350,7 @@ with the digits in the wrong order.
 
 You have to enter your 8-digit password using this Frenchy keypad.
 
-|caf.fr|
+.. image:: /screenshots/caf.png
 
 
 `California Department of Motor Vehicles <https://www.dmv.ca.gov/FIM/sps/uscfed/usc/self/account/create>`__
@@ -360,7 +360,7 @@ They also prohibit pasting into the password field by using a JavaScript
 ``alert()`` whenever you right-click or press the ``Ctrl`` button, so
 you can't use a password manager.
 
-|California DMV|
+.. image:: /screenshots/ca-dmv.png
 
 
 `Canada Revenue Agency <https://cms-sgj.cra-arc.gc.ca/gol-ged/awsc/cms/registration/start>`__
@@ -377,7 +377,7 @@ Password checklist:
 - No special characters except: dot (.), dash (-), underscore (_), and apostrophe (')
 - No more than 4 consequetive identical characters
 
-|Canada Revenue Agency|
+.. image:: /screenshots/CanadaRevenueAgency.png
 
 
 `Capital One <https://myaccounts.capitalone.com/security/changePassword>`__
@@ -386,7 +386,7 @@ Password checklist:
 - May only use the following characters: Aa-Zz 0-9 - _ . / \\ @ $ * & ! #
 - No spaces
 
-|Capital One|
+.. image:: /screenshots/capitalone.png
 
 
 `CenturyLink <https://eam.centurylink.com/eam/login.do>`__
@@ -395,7 +395,7 @@ Password checklist:
 So many bad ideas: a low maximum length, requiring six specific character types while not accepting common symbols,
 plus a weird restriction that makes random generation harder.
 
-|CenturyLink|
+.. image:: /screenshots/centurylink.png
 
 
 `Credit Agricole <https://www.credit-agricole.fr/ca-paris/particulier/acceder-a-mes-comptes.html0>`__
@@ -404,7 +404,7 @@ plus a weird restriction that makes random generation harder.
 * Login is a predefined 11 digits long identifier that you can not change
 * Password is a 6 digits long identifier that you need to input using your mouse
 
-|Credit Agricole|
+.. image:: /screenshots/ca-paris.png
 
 
 `Charles Sturt University <https://www.csu.edu.au/division/dit/services/services/access-and-logins/password-management>`__
@@ -412,7 +412,7 @@ plus a weird restriction that makes random generation harder.
 
 Prevents spaces and a set list of characters, limits to 30 characters and can only change your password twice per day.
 
-|csu.edu.au|
+.. image:: /screenshots/csu.edu.au.png
 
 
 `Chase Bank <https://secure01a.chase.com/web/auth/dashboard>`__
@@ -423,7 +423,7 @@ Prevents spaces and a set list of characters, limits to 30 characters and can on
 * No runs of identical characters ("aaa") or sequential characters ("abc").
 * Password check is case-insensitive
 
-|Chase|
+.. image:: /screenshots/chase.jpg
 
 
 `Chegg <https://www.chegg.com/auth?action=signup>`__
@@ -431,9 +431,9 @@ Prevents spaces and a set list of characters, limits to 30 characters and can on
 
 Here are the (only fairly poor) rules for a new password. Enter 64 character password that matches all the rules (notice no rules on maximum length). That password you entered looks good! But we didn't change it. And your old password doesn't work. Or the new one. ¯\\\_(ツ)\_/¯
 
-|Chegg1|
-|Chegg2|
-|Chegg3|
+.. image:: /screenshots/chegg1.png
+.. image:: /screenshots/chegg2.png
+.. image:: /screenshots/chegg3.png
 
 
 `Canadian Imperial Bank of Commerce <https://www.cibconline.cibc.com>`__
@@ -441,7 +441,7 @@ Here are the (only fairly poor) rules for a new password. Enter 64 character pas
 
 Letters and numbers only, no symbols. Also an undocumented maximum of 12 characters!
 
-|CIBC|
+.. image:: /screenshots/CIBC.png
 
 
 `Comcast <https://customer.xfinity.com/#/settings/security/xfinity-access/password>`__
@@ -456,7 +456,7 @@ characters long.
 
 A max of 12 characters... Can't handle most symbols (only 5 supported). At least they have two factor auth via email or sms * *sigh* *
 
-|Cigna|
+.. image:: /screenshots/my.cigna.com.png
 
 
 `Citi <https://www.citi.com>`__
@@ -467,7 +467,7 @@ A max of 12 characters... Can't handle most symbols (only 5 supported). At least
 * Allows for a minimum password length of 6 characters
 * No runs of more than two identical characters (eg. "aaa" is not allowed.)
 
-|Citi|
+.. image:: /screenshots/citi.png
 
 
 `Commsec <https://www2.commsec.com.au/selfservice/resetpassword>`__
@@ -475,7 +475,7 @@ A max of 12 characters... Can't handle most symbols (only 5 supported). At least
 
 Another financial institution with short password requirements. They also block pasting in to the field, making it a pain to use a password manager.
 
-|Commsec|
+.. image:: /screenshots/commsec.png
 
 
 `Copart <https://copart.com>`__
@@ -485,7 +485,7 @@ Copart: "The security of our members is extremely imporant to us."
 
 Also Copart: "We're gonna need you to keep your password between 5-10 characters."
 
-|Copart|
+.. image:: /screenshots/copart.png
 
 
 `Copyright.gov <https://www.copyright.gov/eco/help-password-userid.html>`__
@@ -493,7 +493,7 @@ Also Copart: "We're gonna need you to keep your password between 5-10 characters
 
 I wonder if they cooperate with NSA to enforce the password rules.
 
-|Copyright.gov|
+.. image:: /screenshots/copyright-gov.png
 
 
 `Coventry Building Society <https://www.coventrybuildingsociety.co.uk/>`__
@@ -501,7 +501,7 @@ I wonder if they cooperate with NSA to enforce the password rules.
 
 Password has to be between 6 and 10 characters, can't contain any punctuation and you have to give characters from it on the phone to confirm identity.
 
-|Coventry Building Society|
+.. image:: /screenshots/coventry-building-society.png
 
 
 `Crédit Agricole Centre-Est <https://www.ca-centrest.fr>`__
@@ -509,7 +509,7 @@ Password has to be between 6 and 10 characters, can't contain any punctuation an
 
 You have to enter your 6-digit password using this Frenchy keypad.
 
-|ca-centrest.fr|
+.. image:: /screenshots/ca-centrest.png
 
 
 `CVent <https://www.cvent.com>`__
@@ -520,7 +520,7 @@ Password Rules
 - 8 to 20 characters with at least 1 number and 1 letter.
 - No symbols or spaces.
 
-|CVent|
+.. image:: /screenshots/cvent.png
 
 
 `CWT Business Travel Management Company <https://travel.mycwt.com>`__
@@ -532,7 +532,7 @@ Password:
 - Must be different from your username
 - Must be different from 5 previous passwords
 
-|CWT|
+.. image:: /screenshots/cwt.png
 
 
 `DBS Bank (Singapore) <https://internet-banking.dbs.com.sg/IB/Welcome>`__
@@ -540,7 +540,7 @@ Password:
 
 ``[[:digit:]]{6,8}``
 
-|DBS|
+.. image:: /screenshots/dbs.png
 
 
 `Dell <https://www.dell.com/Identity/global/LoginOrRegister>`__
@@ -551,7 +551,7 @@ Oh at least one number and one letter, bit dumb but hey not that dumb.
 
 But hiding the fact that it has a max of 20, now THAT is dumb!
 
-|Dell|
+.. image:: /screenshots/dell.png
 
 
 `Deloitte GlobalAdvantage <http://www.ga.deloitte.com/>`__
@@ -560,7 +560,7 @@ But hiding the fact that it has a max of 20, now THAT is dumb!
 Rules that are completely arbitrary that basically make all safe passwords wrong,
 instead forcing pseudo-safe password combinations.
 
-|Deloitte GlobalAdvantage|
+.. image:: /screenshots/deloitte.png
 
 
 `Delta <https://www.delta.com/us/en/advisories/other-alerts/password-security>`__
@@ -568,7 +568,7 @@ instead forcing pseudo-safe password combinations.
 
 It's a good thing they don't store personal information such as your passport number... oh wait.
 
-|Delta|
+.. image:: /screenshots/delta.jpg
 
 
 `Discovery Benefits <https://benefitslogin.discoverybenefits.com/Login.aspx>`__
@@ -577,8 +577,8 @@ It's a good thing they don't store personal information such as your passport nu
 Requires at least one symbol, but must be one of `! @ # $ % & * ?`, and also
 has an unstated max length of 20 characters.
 
-|Discovery Benefits 1|
-|Discovery Benefits 2|
+.. image:: /screenshots/discovery-benefits-1.png
+.. image:: /screenshots/discovery-benefits-2.png
 
 
 `DJI <https://account.dji.com/register>`__
@@ -586,7 +586,7 @@ has an unstated max length of 20 characters.
 
 The symbol `\\` is banned without a notice, it'll probably escape whatever you'll put in, just why...
 
-|DJI|
+.. image:: /screenshots/dji-drones.png
 
 
 `Dnevnik.ru <https://login.dnevnik.ru/login>`__
@@ -596,7 +596,7 @@ Silently (sic!) trim password to 30 symbols.
 
 That causes the stupid case when you could successfully registrate an account with password length of 52 and can't login with the password.
 
-|dnevnik|
+.. image:: /screenshots/dnevnik.png
 
 
 `Dutch Tax Authorities (Belastingdienst) <https://www.belastingdienst.nl/>`__
@@ -609,7 +609,7 @@ No more than 3 special characters.
 
 It's not like hashing passwords is a thing or something.
 
-|Dutch Tax Authorities|
+.. image:: /screenshots/belastingdienst.jpg
 
 
 `Easybank (Austrian direct bank) <https://www.easybank.at/de/>`__
@@ -622,7 +622,7 @@ It's not like hashing passwords is a thing or something.
 - "Simple" patterns are prohibited
 - PINs are case sensitive (at least it's something)
 
-|Easybank|
+.. image:: /screenshots/easybank.png
 
 
 `Easyjet <https://www.easyjet.com/en>`__
@@ -630,7 +630,7 @@ It's not like hashing passwords is a thing or something.
 
 No more than 20 characters, use any symbols you like... Oh except #, &, +, or space of course.
 
-|Easyjet|
+.. image:: /screenshots/easyjet.png
 
 
 `El Corte Ingles <https://www.elcorteingles.es/profile2/profile/registration/registroCliente.jsp?tiendaId=moonshine&pag_regreso=www.elcorteingles.es>`__
@@ -640,7 +640,7 @@ Min 6 and max 8 characters for password! Can't contain anything
 different than letters and numbers. Apart, the email address must have
 at least 8 characters (sorry million dollar domain owners! :D)
 
-|El Corte Ingles|
+.. image:: /screenshots/elcorteingles.png
 
 
 `E-learning (Unipd) <https://elearning.studenti.math.unipd.it/authenticate/change_password/>`__
@@ -650,7 +650,7 @@ Exactly 8 characters for password! There must be at least 1 lowercase
 letter, at least 1 uppercase letter, at least 1 number and at least 1
 *special* char ( \* , . $ # @ etc...).
 
-|e-learning (Unipd)|
+.. image:: /screenshots/elearning.math.unipd.png
 
 
 `Electronic Arts (EA) <https://www.ea.com/register>`__
@@ -658,7 +658,7 @@ letter, at least 1 uppercase letter, at least 1 number and at least 1
 
 Your password must be 8 - 16 characters, and include at least one lowercase letter, one uppercase letter, and a number.
 
-|Electronic Arts|
+.. image:: /screenshots/electronic-arts.png
 
 
 `EllieMae Access <https://access.elliemae.com/home>`__
@@ -667,9 +667,9 @@ Your password must be 8 - 16 characters, and include at least one lowercase lett
 Must reset password every 6 months and password requirements are not displayed _anywhere_.
 Reset uses a Security Question, and you have to choose from a list of 5.
 
-|EllieMae1|
-|EllieMae2|
-|EllieMae3|
+.. image:: /screenshots/elliemae1.png
+.. image:: /screenshots/elliemae2.png
+.. image:: /screenshots/elliemae3.png
 
 
 `E-Trade <https://us.etrade.com/e/t/user/login>`__
@@ -685,7 +685,7 @@ If your account has a 32-character password and has two-factor authentication,
 their system appears to cut off the token, making it impossible to login.
 You must reduce your password to 26 characters in order to login with a token.
 
-|ETrade|
+.. image:: /screenshots/etrade.png
 
 
 `FACE IT Ltd. (Faceit) <https://www.faceit.com/en/signup>`__
@@ -693,7 +693,7 @@ You must reduce your password to 26 characters in order to login with a token.
 
 Your password must be 6 - 20 characters. No special characters or numbers required.
 
-|Faceit|
+.. image:: /screenshots/faceit.png
 
 
 `Fidelity <https://fps.fidelity.com/ftgw/Fps/Fidelity/RtlCust/ChangePIN/Init>`__
@@ -702,7 +702,7 @@ Your password must be 6 - 20 characters. No special characters or numbers requir
 No more than 20 characters and leave out characters commonly used by
 programmers. We don't want you to hack the mainframe.
 
-|Fidelity|
+.. image:: /screenshots/fidelity.png
 
 
 `Fidelity National Information Services <https://www.fisglobal.com/>`__
@@ -712,7 +712,7 @@ White label online banking provider. Typically appears as `BANK.ibanking-service
 
 ``\<>'`` and spaces prohibited, upper bound. Passwords of exactly the maximum length are truncated by one character. Unlisted prohibited characters.
 
-|FIS Global|
+.. image:: /screenshots/fisglobal.png
 
 
 `EON <https://www.eonenergy.com/for-your-home/your-account/forgotten-password/non-link-reset/Reset>`__
@@ -720,7 +720,7 @@ White label online banking provider. Typically appears as `BANK.ibanking-service
 
 By the time I'd finished reading the rules I've forgotten all of them.
 
-|EON|
+.. image:: /screenshots/eon.png
 
 
 `Fundatec <http://www.fundatec.org.br/>`__
@@ -728,7 +728,7 @@ By the time I'd finished reading the rules I've forgotten all of them.
 
 Must be exactly 6 alphanumeric characters, does not show special characters are not allowed, username is your social security number (easily searchable) and the form is sent over plain HTTP. Did I mention this company applies college entrance exams for **Computer Science** nationwide in Brazil?
 
-|Fundatec|
+.. image:: /screenshots/fundatec.png
 
 
 `Gebührenfrei MasterCard <https://www.gebuhrenfrei.com/>`__
@@ -736,7 +736,7 @@ Must be exactly 6 alphanumeric characters, does not show special characters are 
 
 The new password can only have 6-12 characters. It *may* contain letters, numbers and a fixed set of special characters.
 
-|Gebührenfrei MasterCard|
+.. image:: /screenshots/gebuhrenfrei-mastercard.png
 
 
 `Getin Bank <https://secure.getinbank.pl/>`__
@@ -747,7 +747,7 @@ The password must contain at least one upper case letter, one lower case
 letter and one number. The password cannot contain non-ASCII Polish alphabet
 characters, special characters ``&<'"`` or spaces.
 
-|Getin Bank|
+.. image:: /screenshots/getin.png
 
 
 `Global Entry <https://goes-app.cbp.dhs.gov/goes/PasswordChangePreAction.do>`__
@@ -756,7 +756,7 @@ characters, special characters ``&<'"`` or spaces.
 "Our duties are wide-ranging, and our goal is clear - keeping America
 safe."
 
-|Global Entry|
+.. image:: /screenshots/global-entry.png
 
 
 `GoDaddy <https://www.godaddy.com/>`__
@@ -764,7 +764,7 @@ safe."
 
 Some characters are **too** special.
 
-|GoDaddy|
+.. image:: /screenshots/godaddy.png
 
 
 `GoDaddy SFTP <https://www.godaddy.com/>`__
@@ -772,7 +772,7 @@ Some characters are **too** special.
 
 Max 14 characters for the most important password in your shared hosting environment.
 
-|GoDaddy SFTP|
+.. image:: /screenshots/godaddy-sftp.png
 
 
 `GoFundMe <https://www.gofundme.com/sign-up>`__
@@ -782,7 +782,7 @@ Max 14 characters for the most important password in your shared hosting environ
 - At least one number and one special symbol
 - Does not specify which characters are considered special symbols; did not recognize spaces as special symbols
 
-|GoFundMe|
+.. image:: /screenshots/gofundme.png
 
 
 `Green Flag <https://www.greenflag.com//>`__
@@ -791,8 +791,8 @@ Max 14 characters for the most important password in your shared hosting environ
 - 8 to 10 characters
 - No special characters
 
-|GreenFlag1|
-|GreenFlag2|
+.. image:: /screenshots/green-flag-1.png
+.. image:: /screenshots/green-flag-2.png
 
 
 `Her Majesty’s Revenue & Customs (UK Tax) <https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fpersonal-account%2Fdo-uplift&origin=unknown>`__
@@ -800,7 +800,7 @@ Max 14 characters for the most important password in your shared hosting environ
 
 We store basically all of your data, but we can't store your password.
 
-|Her Majesty’s Revenue & Customs|
+.. image:: /screenshots/tax.service.gov.uk.png
 
 
 `Hetzner <https://hetzner.com>`__
@@ -816,7 +816,7 @@ Okay, fair enough, but after putting in a password with some special characters 
 
 You can't use ``&<>'"\|´```, spaces and any other non-ascii character.
 
-|Hetzner|
+.. image:: /screenshots/hetzner.png
 
 
 `IBM <https://www.ibm.com/>`__
@@ -825,7 +825,7 @@ You can't use ``&<>'"\|´```, spaces and any other non-ascii character.
 Password cannot be longer then 31 characters.
 Spaces, ?, ../, curly braces and double byte character not allowed
 
-|IBM|
+.. image:: /screenshots/ibm.png
 
 
 `IHG <https://www.ihg.com/rewardsclub/us/en/join/register>`__
@@ -833,7 +833,7 @@ Spaces, ?, ../, curly braces and double byte character not allowed
 
 4, yes 4, digits only.
 
-|IHG|
+.. image:: /screenshots/ihg.png
 
 
 `ING a dutch bank in almost 50 countries <https://www.ing.nl/>`__
@@ -845,7 +845,7 @@ When i asked about it they answer that it's really hard to change it.
 When i asked if the password is saved as a hash or just plain they send the answer to the technical department
 this was march 2018.
 
-|ING Bank|
+.. image:: /screenshots/ingbank.png
 
 
 `ING Australia <https://www.ing.com.au/securebanking/>`__
@@ -854,7 +854,7 @@ this was march 2018.
 4 numeric digits.
 "Added security" by randomising the positions on the keypad. Must be clicked.
 
-|ING Australia|
+.. image:: /screenshots/ingaustralia.png
 
 
 `ING Romania's Internet Banking Portal <https://www.homebank.ro/>`__
@@ -865,7 +865,7 @@ online transactions. They used to have "normal" passwords and they forced everyb
 change to the 5 digits versions. They said they've made it "so it's easier for you" and it's
 OK, because everybody has 2FA.
 
-|ING Romania|
+.. image:: /screenshots/ingromania.jpg
 
 
 `Inria <https://vpn1-roc.national.inria.fr/+CSCOE+/logon.html>`__
@@ -891,7 +891,7 @@ the other ones.
 - Your password cannot contain your last name (or substring of last name)
 - Your password cannot contain your first name (or substring of first name)
 
-|Inria|
+.. image:: /screenshots/inria.png
 
 
 `INSS (Instituto Nacional do Seguro Social) <https://www.inss.gov.br/>`__
@@ -903,13 +903,13 @@ The National Social Security Institute (INSS) is an autarchy of the Government o
 - Exact 9 digits
 - At least 1 lowercase, 1 uppercase letter and a 1 number
 
-|INSS|
+.. image:: /screenshots/inss.png
 
 
 `Intel <https://www-ssl.intel.com/content/www/uk/en/my-intel/reseller-sign-in-help.html>`__
 ~~~~
 
-|Intel|
+.. image:: /screenshots/intel.jpg
 
 
 `Interactive Brokers <https://ndcdyn.interactivebrokers.com/Universal/servlet/Application.ApplicationSelector>`__
@@ -933,7 +933,7 @@ restrictions too:
 - Contain at least 1 number
 - Case sensitive, **no spaces, no special characters**
 
-|Interactive Brokers|
+.. image:: /screenshots/interactive_brokers.png
 
 
 `Izly by Crous <https://mon-espace.izly.fr/Home/Logon>`__
@@ -951,7 +951,7 @@ How convenient indeed.
 
 Oh and also look we got pages **NOT TRANSLATED IN FRENCH** because duh.
 
-|Izly by Crous|
+.. image:: /screenshots/izly-by-crous.png
 
 
 `Lloyds Bank <https://online.lloydsbank.co.uk/personal/logon/login.jsp>`__
@@ -963,7 +963,7 @@ with a known phrase (The "Memorable Information") of which you will be
 asked for a random 3 characters of if you get your password right.
 This phrase has similar alpha-numeric restrictions applied.
 
-|Lloyds|
+.. image:: /screenshots/lloyds.png
 
 
 `Jitterbit <https://www.jitterbit.com/>`__
@@ -975,7 +975,7 @@ While not the dumbest password rule, still dumb.
     at least one: number, special char ``!#$%-_=+<>``, capital letter,
     and lowercase letter.
 
-|Jitterbit|
+.. image:: /screenshots/jitterbit.png
 
 
 `Keimyung University <https://sso.kmu.ac.kr/kmusso/ext/edward/login_form.do/>`__
@@ -986,9 +986,9 @@ Okay, doesn't looks that hard... But wait, there are hidden rules!
     Hidden rules: your password can't have 3 times the same character in a row or more than 2 consecutive numbers.
     Also if your password is 20 characters or more you won't be able to write it in the mobile app.
 
-|Keimyung1|
-|Keimyung2|
-|Keimyung3|
+.. image:: /screenshots/keimyung1.png
+.. image:: /screenshots/keimyung2.png
+.. image:: /screenshots/keimyung3.png
 
 
 `Kryterion Webassessor <https://webassessor.com/googlecloud>`__
@@ -996,7 +996,7 @@ Okay, doesn't looks that hard... But wait, there are hidden rules!
 
 I was quite suprised to see this when I was registering for my Google Professional Cloud **Security** Engineer certification. Nice part is that they **don't allow quotes** as special character, so I assume there possibly might be some other issues on their backends. :-)
 
-|Kryterion Webassessor|
+.. image:: /screenshots/webassessor.png
 
 
 `LCL <https://www.lcl.fr>`__
@@ -1004,7 +1004,7 @@ I was quite suprised to see this when I was registering for my Google Profession
 
 You have to enter your 6-digit password using this Frenchy keypad.
 
-|lcl.fr|
+.. image:: /screenshots/lcl.png
 
 
 `LibraryThing <https://www.librarything.com/>`__
@@ -1012,7 +1012,7 @@ You have to enter your 6-digit password using this Frenchy keypad.
 
 "Your password cannot be longer than 20 characters"
 
-|LibraryThing|
+.. image:: /screenshots/librarything.png
 
 
 `Lowes <https://www.lowes.com/mylowes/login>`__
@@ -1023,7 +1023,7 @@ You have to enter your 6-digit password using this Frenchy keypad.
 - Contain no spaces
 - Contain no more than 3 of the same consecutive characters
 
-|Lowes|
+.. image:: /screenshots/lowes.png
 
 
 `MarketWatch <http://www.marketwatch.com/>`__
@@ -1033,14 +1033,14 @@ You have to enter your 6-digit password using this Frenchy keypad.
 - Must contain one number.
 - Cannot contain spaces, %, & or +.
 
-|MarketWatch|
+.. image:: /screenshots/marketwatch.png
 
 
 `Maxpreps <http://www.maxpreps.com/>`__
 ~~~~
 `Natalie Weiner <https://twitter.com/natalieweiner/status/1034533245839450113?s=19>`__
  can't sign in because her's lastname is offensive language for the website
-|Maxpreps|
+.. image:: /screenshots/maxpreps.png
 
 
 `ME Bank <https://ib.mebank.com.au/authR5/ib/login.jsp>`__
@@ -1054,7 +1054,7 @@ You have to enter your 6-digit password using this Frenchy keypad.
 - Cannot have pairs next to each other if the second pair is one number higher.
 - Cannot be the same as 8 previous ones.
 
-|ME Bank|
+.. image:: /screenshots/me-bank.png
 
 
 `Merrill Lynch <https://www.benefits.ml.com/Core/User/ChangePassword>`__
@@ -1065,7 +1065,7 @@ characters are allowed. Users with randomly-generated passwords may find
 it particularly annoying to generate a password that works for their
 password safe.
 
-|Merrill Lynch|
+.. image:: /screenshots/merrill-lynch.png
 
 
 `Major League Baseball <https://securea.mlb.com/enterworkflow.do?flowId=registration.connect.wizard&c_id=mlb&template=mobile&forwardUrl=https://www.mlb.com>`__
@@ -1075,7 +1075,7 @@ When creating a new account they enforce some password rules like: length must b
 between 8 and 15 characters and there must be one upper case, one lower case letter
 and one number.
 
-|MLB|
+.. image:: /screenshots/mlb.png
 
 
 `MetLife <https://online.metlife.com/edge/web/profile/viewProfile?show=profileSettings>`__
@@ -1084,7 +1084,7 @@ Max length of 20 characters, no special characters allowed.
 Pasting into the second password field is disabled even with
 the Chrome extension Don't Fuck With Paste.
 
-|MetLife|
+.. image:: /screenshots/metlife.png
 
 
 `Microsoft (work accounts) <https://account.activedirectory.windowsazure.com/ChangePassword.aspx>`__
@@ -1100,7 +1100,7 @@ Oh - and besides that, please don't use any "exotic" symbols, like ¤ or
 €. Or the letters Æ, Ø or Å from the Danish alphabet. They all are
 supposedly "spaces".
 
-|Microsoft (work accounts)|
+.. image:: /screenshots/microsoftwork.png
 
 
 `Mindware <https://secure.mindware.orientaltrading.com/web/login/createUser>`__
@@ -1118,14 +1118,14 @@ necessarily tell you which ones.
 Using a 16 character password seems to work. Everything else above does not always work.
 Also, passwords that are too long are still changed, so you have to reset them by email.
 
-|Minecraft|
+.. image:: /screenshots/Minecraft.png
 
 
 `Minnesota Unemployment Insurance <https://uimn.org>`__
 ~~~~
 Locked to *exactly* 6 chars, alphanumeric only, not special chars.
 
-|Minnesota UI|
+.. image:: /screenshots/minnesota_ui.png
 
 
 `MKB NetBankár <https://www.mkbnetbankar.hu/>`__
@@ -1144,7 +1144,7 @@ Locked to *exactly* 6 chars, alphanumeric only, not special chars.
   during registration, but only the first 16 will get actually used as
   password.
 
-|MKB NetBankár|
+.. image:: /screenshots/mkb.png
 
 
 `Mobi Bike Share <https://www.mobibikes.ca/en/register>`__
@@ -1152,7 +1152,7 @@ Locked to *exactly* 6 chars, alphanumeric only, not special chars.
 
 Your PIN (which is the password you use to login, which lets you, say, buy hundreds of dollars worth of bike-share subscriptions off the saved credit card) must be four numeric digits. Helpfully, they even give you an example of a PIN: *1234*.
 
-|Mobi Bike Share|
+.. image:: /screenshots/mobibikes.png
 
 
 `Movistar <https://www.movistar.es/particulares/Privada/Registro/?url=%2Fmimovistar-cliente%2Fes-es%2Fparticulares%2Fregistro%2FdatosUsuario.html&>`__
@@ -1164,7 +1164,7 @@ surname of the user with some characters replaced by digits :)
 
 Has been that way for more than 10 years.
 
-|MobileIron|
+.. image:: /screenshots/mobileiron.png
 
 
 `MobileIron MDM <https://www.mobileiron.com/>`__
@@ -1175,7 +1175,7 @@ characters, no alphabetic sequences, no whitespace, 3 character sets,
 maximum of 32 characters.
 
 
-|Movistar|
+.. image:: /screenshots/movistar.jpg
 
 
 `Mycanal <https://www.mycanal.fr/>`__
@@ -1185,7 +1185,7 @@ maximum of 32 characters.
 - Contain at least 1 uppercase character or 1 number
 - Can not contain these characters : ‹ › ' "
 
-|Mycanal|
+.. image:: /screenshots/mycanal.png
 
 
 `MySwissLife <https://myswisslife.fr/#/login>`__
@@ -1193,8 +1193,8 @@ maximum of 32 characters.
 
 User ID *has to* be 8 characters exactly, password *has to be* 8 characters and numbers only.
 
-|myswisslife-1|
-|myswisslife-2|
+.. image:: /screenshots/myswisslife-1.jpg
+.. image:: /screenshots/myswisslife-2.jpg
 
 
 `NBank <https://www.nbank.de/Service/Kundenportal/Zugang-zum-Kundenportal/index.jsp>`__
@@ -1202,7 +1202,7 @@ User ID *has to* be 8 characters exactly, password *has to be* 8 characters and 
 
 User ID *has to* contain special characters, password *may not* contain (basically) any special characters.
 
-|NBank|
+.. image:: /screenshots/nbank.jpg
 
 
 `NBC (National Bank of Canada) <https://www.nbc.ca>`__
@@ -1211,10 +1211,10 @@ User ID *has to* contain special characters, password *may not* contain (basical
 - Password length must be 8 to 25 characters
 - Password must contain at least one lower letter (any position)
 - Password must contain at least one digit (any position)
-- Password cannot contain spaces. 
+- Password cannot contain spaces.
 - Copy/paste is not allowed when trying to set a new password
 
-|NationalBankOfCanada|
+.. image:: /screenshots/nbc.png
 
 
 `Nectar API <https://api.nectar.com/oauth/authorize>`__
@@ -1225,7 +1225,7 @@ However, when trying to link my Sainsbury's account, I found the API has differe
 
 - Password field length capped to 16 characters
 
-|NectarApi|
+.. image:: /screenshots/nectar-api.png
 
 
 `Netflix <https://www.netflix.com/>`__
@@ -1236,7 +1236,7 @@ and the `password reset page <https://www.netflix.com/password>`__ say:
 
     Ihr Passwort muss zwischen 4 und 60 Zeichen lang sein und darf keine Tilde (~) enthalten.
 
-    |Netflix|
+    .. image:: /screenshots/netflix.png
 
 Disallowing a 64-bit hex password, as generated by KeePass, ist unnecessarily restrictive.
 
@@ -1254,13 +1254,13 @@ It seems to be only written down to irritate customers.
 - Password must contain one of the following special characters: @ # $
 - Password is not case sensitive
 
-|Nevada DMV|
+.. image:: /screenshots/dmvapp.nv.gov.png
 
 
 `NVV (Nordhessische VerkehrsVerbund) <https://nvv.mobilesticket.de/ticketportal/register.jsf>`__
 ~~~~
 
-|NVV|
+.. image:: /screenshots/nvv.png
 
 Password length must be 4 to 10 characters with only a few special characters allowed.
 
@@ -1270,7 +1270,7 @@ Password length must be 4 to 10 characters with only a few special characters al
 
 Password length must be 8 to 20 characters long with lower case characters and numbers only.
 
-|Omnivox|
+.. image:: /screenshots/omnivox.png
 
 
 `Onleihe <https://www4.onleihe.de/essen/frontend/myBib,0-0-0-100-0-0-0-0-0-0-0.html>`__
@@ -1278,7 +1278,7 @@ Password length must be 8 to 20 characters long with lower case characters and n
 
 Password is your birthday in format ddmmyyyy. Users are not allowed to change their passwords
 
-|Onleihe|
+.. image:: /screenshots/onleihe.png
 
 
 `Oracle <https://profile.oracle.com/>`__
@@ -1287,7 +1287,7 @@ Password is your birthday in format ddmmyyyy. Users are not allowed to change th
 *Should not* or *must not*? RFC 2119 may want a word with you.
 
 
-|Oracle|
+.. image:: /screenshots/oracle.png
 
 
 `Origin <https://www.origin.com/>`__
@@ -1295,7 +1295,7 @@ Password is your birthday in format ddmmyyyy. Users are not allowed to change th
 
 Password must be between 8 and 16 characters long
 
-|Origin|
+.. image:: /screenshots/origin.png
 
 
 `PagoMisCuentas <https://www.pagomiscuentas.com/>`__
@@ -1304,7 +1304,7 @@ Password must be between 8 and 16 characters long
 Password must be between 8 and 15 alphanumeric characters, and have
 at least one uppercase and one lowercase letter.
 
-|PagoMisCuentas|
+.. image:: /screenshots/pagomiscuentas.png
 
 
 `Parnassus Investments <https://www.parnassus.com/your-account/newaccount/open-account-intro/>`__
@@ -1313,7 +1313,7 @@ at least one uppercase and one lowercase letter.
 A site responsible for protecting your investments limiting you to a
 four character range with a bunch of other stupid rules? Shocking.
 
-|Parnassus|
+.. image:: /screenshots/parnassus.png
 
 
 `PayPal <https://www.paypal.com/welcome/signup>`__
@@ -1321,7 +1321,7 @@ four character range with a bunch of other stupid rules? Shocking.
 
 Must be between 8 and 20 characters, no spaces, uppercase and lowercase, one symbol...
 
-|PayPal|
+.. image:: /screenshots/paypal.png
 
 
 `Paytm <https://paytm.com/>`__
@@ -1330,7 +1330,7 @@ Must be between 8 and 20 characters, no spaces, uppercase and lowercase, one sym
 Password must be between 5 and 15 characters. Also, spaces don't count
 as characters.
 
-|Paytm|
+.. image:: /screenshots/paytm.png
 
 
 `PCPartPicker <https://pcpartpicker.com>`__
@@ -1339,7 +1339,7 @@ as characters.
 There are no rules for passwords. Passwords can be any length (including one character)
 of any complexity. No password change confirmation emails are sent.
 
-|PCPartPicker|
+.. image:: /screenshots/pcpartpicker.png
 
 
 `PizzaHut <https://www.pizzahut.com/>`__
@@ -1347,9 +1347,9 @@ of any complexity. No password change confirmation emails are sent.
 
 Passwords must be greater than 6 characters, and have an arbitrary set of rules we don't tell you about until after you try to set your password.
 
-|PizzaHut-1|
-|PizzaHut-2|
-|PizzaHut-3|
+.. image:: /screenshots/pizzahut1.png
+.. image:: /screenshots/pizzahut2.png
+.. image:: /screenshots/pizzahut3.png
 
 
 `Pole-Emploi <https://www.pole-emploi.fr/accueil/>`__
@@ -1360,14 +1360,14 @@ It rejected passwords generated by pass, while accepting ``p@ssw0rd!``...
 They also block pasting on the password confirmation field,
 forcing you to manually type your 32-letters-long generated password.
 
-|PoleEmploi|
+.. image:: /screenshots/pole-emploi.png
 
 `Premera Blue Cross <https://account.premera.com/>`__
 
 Password must contain 8-30 characters, including one letter and one number.
 "Special characters allowed" seems to mean a very small handful of choices you can only find through trial and error  ``-_'.@``
 
-|Premera|
+.. image:: /screenshots/premera.png
 
 
 `Progressive Home by Homesite <https://progressivedirect.homesite.com/OnlineServicing/>`__
@@ -1385,7 +1385,7 @@ https://progressivedirect.homesite.com/OnlineServicing/Welcome.aspx#RecoverPassw
 
 However, when you log in, it only allows passwords up to 12 characters in length. So that newly created password will work once and only once.
 
-|Progressive Home by Homesite|
+.. image:: /screenshots/progressive-homesite.png
 
 
 `Raiffeisen Bank Serbia <https://rol.raiffeisenbank.rs/Retail/home/login/>`__
@@ -1397,7 +1397,7 @@ minimum 8 and maximum 16 characters. Also, minimum uppercase letters 1, minimum
 lowercase letter 1, minimum digits 2, maximum consecutive identical characters 4
 and first character must be a letter. Oh... And, no special characters!
 
-|Raiffeisen Bank Serbia|
+.. image:: /screenshots/raiffeisen_bank_srb.png
 
 
 `Red Hat <https://www.redhat.com/>`__
@@ -1406,7 +1406,7 @@ and first character must be a letter. Oh... And, no special characters!
 Symbols. You keep using that word. I don't think it means what you think
 it means.
 
-|Red Hat|
+.. image:: /screenshots/redhat.png
 
 
 `Rediff <https://www.rediff.com/>`__
@@ -1419,7 +1419,7 @@ A maximum password length of 12. The hidden requirements are:
 - atleast 1 numeric character
 - atleast 1 special symbol (which can not be ^, %)
 
-|Rediff|
+.. image:: /screenshots/rediff.png
 
 
 `Rogers <https://rogers.com>`__
@@ -1432,7 +1432,7 @@ Password guidelines
 - Your password should be between 8-20 characters and have at least one number and one letter.
 - The following special characters are allowed: ! @ # $
 
-|Rogers|
+.. image:: /screenshots/rogers.png
 
 
 `Roll 20 <https://app.roll20.net/>`__
@@ -1440,7 +1440,7 @@ Password guidelines
 
 Your new password must be at least 4 characters long and no longer than 40 characters. Your password was not changed.
 
-|Roll 20|
+.. image:: /screenshots/Roll20.png
 
 
 `Rushmore Loan Management Services <https://rushmore.customercarenet.com/>`__
@@ -1448,7 +1448,7 @@ Your new password must be at least 4 characters long and no longer than 40 chara
 
 Hmmm.. why are they afraid of double and single quotes in my passwords?
 
-|Rushmore|
+.. image:: /screenshots/rushmore-loan-managment-services.png
 
 
 `SAP Cloud Appliance Library <https://cal.sap.com/>`__
@@ -1456,7 +1456,7 @@ Hmmm.. why are they afraid of double and single quotes in my passwords?
 
 Passwords between 8 and 9 characters are the best.
 
-|SAP Cloud Appliance Library|
+.. image:: /screenshots/sapcal.png
 
 
 `Scandinavian Airlines <https://www.flysas.com/us-en/>`__
@@ -1475,7 +1475,7 @@ Answer form SAS customer service::
 > I would advice you to change your password.
 > Have a wonderful day.
 
-|Scandinavian Airlines|
+.. image:: /screenshots/sas.no.png
 
 
 `Safeway <https://shop.safeway.com/>`__
@@ -1483,7 +1483,7 @@ Answer form SAS customer service::
 
 Passwords limited to 8-12 characters.
 
-|Safeway|
+.. image:: /screenshots/safeway.png
 
 
 `Sears <https://www.sears.com/>`__
@@ -1494,7 +1494,7 @@ Passwords limited to 8-12 characters.
 Can't repeat same character more than 3 times in a row
 Cannot be or contain your username or email address"
 
-|Sears|
+.. image:: /screenshots/sears.png
 
 
 `Sharekhan <https://www.sharekhan.com/>`__
@@ -1503,7 +1503,7 @@ Cannot be or contain your username or email address"
 - At least 8 characters.
 - At most 12 characters.
 
-|Sharekhan|
+.. image:: /screenshots/sharekhan.png
 
 
 `Singapore Airlines <https://www.singaporeair.com/en_UK/ppsclub-krisflyer/registration-form/>`__
@@ -1511,7 +1511,7 @@ Cannot be or contain your username or email address"
 
 ``/[0-9]{6}/``
 
-|Singapore Airlines|
+.. image:: /screenshots/singaporeairlines.png
 
 
 `Sky Ticket <https://skyticket.sky.de/home/login/>`__
@@ -1521,7 +1521,7 @@ Sky is a german pay-TV provider with over 23 million subscribed users worldwide.
 
 You can only set a **4 digit long PIN** with no option for two-factor authentication or any additional security mechanisms.
 
-|Sky Ticket|
+.. image:: /screenshots/sky-ticket.png
 
 
 `Slovenska sporitelna <https://mysecurity.slsp.sk/zmena-hesla>`__
@@ -1529,7 +1529,7 @@ You can only set a **4 digit long PIN** with no option for two-factor authentica
 
 Slovenska sporitelna is the biggest bank in Slovakia. Despite pretty new version of the internet banking (rolled out in 2018), their password policy restricts password to be 16 characters long at most and prohibits any special characters.
 
-|Slovenska sporitelna|
+.. image:: /screenshots/slsp.png
 
 
 `Sparda-Bank <https://banking.sparda-m.de/spm/?institut=7009>`__
@@ -1537,11 +1537,11 @@ Slovenska sporitelna is the biggest bank in Slovakia. Despite pretty new version
 
 Sparda is a group of German banks. They all use the same login form (except for Sparda-Bank Berlin, see below). Their equivalent of a password is called *Online-PIN*. As the name implies, only digits are allowed. (*Zifferneingabe* means "digit input"; it opens an on-screen number pad widget.)
 
-|Sparda M 1|
+.. image:: /screenshots/sparda-m-1.png
 
 Not mentioned explicitly: Your PIN is limited to 6 characters, i.e. the range of valid "passwords" is from ``000000`` to ``999999``.
 
-|Sparda M 2|
+.. image:: /screenshots/sparda-m-2.png
 
 The odd one out is Sparda-Bank Berlin, which has different rules:
 
@@ -1550,7 +1550,7 @@ The odd one out is Sparda-Bank Berlin, which has different rules:
 - Only the following characters are allowed: a-z, A-Z, ä/Ä, ö/Ö, ü/Ü, ß, 0-9, and the "special characters" ``@!%&/=?*+;:,._-``.
 - Your password must use either digits only (like a PIN) or at least one digit and at least one uppercase letter.
 
-|Sparda B|
+.. image:: /screenshots/sparda-b.png
 
 
 `Southwest <https://https://www.southwest.com>`__
@@ -1559,7 +1559,7 @@ The odd one out is Sparda-Bank Berlin, which has different rules:
 Password must be between 8 and 16 characters in length and include at least one uppercase letter
 and one number. Certain special characters are also allowed, but the first character of the password must be alphanumeric.
 
-|Southwest|
+.. image:: /screenshots/southwest.png
 
 
 `Sparkasse <https://s-jena.de>`__
@@ -1572,7 +1572,7 @@ not even a number, even though it is called as such! Here is a
 screenshot from the branch where I am from (Jena, Germany), but since
 they have a central IT, I think it will be identical in other branches:
 
-|Sparkasse Jena|
+.. image:: /screenshots/sparkasse_jena.png
 
 The rules are as such:
 
@@ -1595,7 +1595,7 @@ like:
 They also have this Android app for 2FA (called Push-TAN), but the rules are
 diffrent:
 
-|push-tan|
+.. image:: /screenshots/push-tan.png
 
 - At least 8 characters
 - At least one digit
@@ -1608,7 +1608,7 @@ diffrent:
 
 Sprint "upgraded" their security and disallow special characters.
 
-|Sprint|
+.. image:: /screenshots/sprint.png
 
 
 `State Bank of India (Foreign Travel Card) <https://prepaid.onlinesbi.com/SBICMS/jsp/Portals/jsp/foreignCard.jsp>`__
@@ -1627,7 +1627,7 @@ Your password must:
 -  Contain at least 1 number
 -  NOT contain any "hacking characters" - #, %, &, =, /, <
 
-|SBI|
+.. image:: /screenshots/sbi.png
 
 
 `Standard Chartered Bank <https://www.sc.com/>`__
@@ -1636,7 +1636,7 @@ Your password must:
 - Between 8 to 16 characters
 - Only letters and/or numbers
 
-|Standard Chartered Bank|
+.. image:: /screenshots/standard-chartered-bank.png
 
 
 `SunTrust <https://www.suntrust.com/>`__
@@ -1644,7 +1644,7 @@ Your password must:
 
 At least there are a variety of special characters to choose from.
 
-|SunTrust|
+.. image:: /screenshots/suntrust.png
 
 
 `Synchrony Financial <https://consumercenter.mysynchrony.com/consumercenter/securityinfoaction_change_password_review_cancel.do>`__
@@ -1653,7 +1653,7 @@ At least there are a variety of special characters to choose from.
 Financial services - where we don't allow you to create the strongest
 password possible.
 
-|Synchrony Financial|
+.. image:: /screenshots/synchrony.png
 
 
 `Taco Bell <https://www.tacobell.com/login/pw/change?token=***>`__
@@ -1661,14 +1661,14 @@ password possible.
 
 Password may include special characters, except for #.
 
-|Taco Bell|
+.. image:: /screenshots/taco-bell.png
 
 
 `Tangerine <https://www.tangerine.ca>`__
 ~~~~
 
 Your PIN can only contain numbers and must be between 4 and 6 numbers.
-|Tangerine|
+.. image:: /screenshots/tangerine.png
 
 
 `Targobank <https://www.targobank.de/de/banque/change_password/UA_Gestion_ChPw.aspx/>`__
@@ -1685,7 +1685,7 @@ Your password must:
 - must not contain three consecutive characters
 - must not contain special characters or umlauts
 
-|Targobank|
+.. image:: /screenshots/targobank.png
 
 
 `T-Mobile <https://account.t-mobile.com/oauth2/v1/changePassword>`__
@@ -1693,7 +1693,7 @@ Your password must:
 
 We prefer to not tell you which characters you can use up front.
 
-|T-Mobile|
+.. image:: /screenshots/tmobile.png
 
 
 `Taiwan Pingtung University <https://webap.nptu.edu.tw/>`__
@@ -1712,7 +1712,7 @@ Password must:
     - This rule is not listed on the official page; however,
     attempting to use a special character will result in an exception.
 
-|NPTU|
+.. image:: /screenshots/nptu.png
 
 
 `Techcombank <https://ib.techcombank.com.vn/servlet/BrowserServlet>`__
@@ -1728,7 +1728,7 @@ Your password must:
   NO special characters is allowed
 - Must be changed every 90 days
 
-|Techcombank|
+.. image:: /screenshots/techcombank.png
 
 
 `Telekom/T-Systems MyWorkplace <https://www.websso.t-systems.com/MyWorkplace/General/TSIPageContainer.aspx>`__
@@ -1741,7 +1741,7 @@ because it is for business customers, there's absolutely no reason
 to limit a password to 16 characters. Even special characters are
 limited to a certain set.
 
-|MyWorkplace|
+.. image:: /screenshots/myworkplace.png
 
 
 `Thames Water <https://www.thameswater.co.uk/>`__
@@ -1749,7 +1749,7 @@ limited to a certain set.
 
 Can only use the "special" characters on that very limited list, excluding symbols so exotic as an underscore, even. This is despite their own strength checker saying the password is strong.
 
-|ThamesWater|
+.. image:: /screenshots/ThamesWater.png
 
 
 `Three <https://www.three.co.uk>`__
@@ -1758,9 +1758,9 @@ Can only use the "special" characters on that very limited list, excluding symbo
 Password must be at least 7 characters long.
 The maximum length is inconsistent, however: when changing password, the maximum length is 30, but when resetting password via email link, the maximum length is 12.
 
-|Three-Change|
+.. image:: /screenshots/three-change.png
 
-|Three-Reset|
+.. image:: /screenshots/three-reset.png
 
 
 `Ticketmaster.de <https://www.ticketmaster.de/myAccount/editProfile>`__
@@ -1768,7 +1768,7 @@ The maximum length is inconsistent, however: when changing password, the maximum
 
 Your password length is limited between 8 and 32 characters.
 
-|Ticketmaster.de|
+.. image:: /screenshots/ticketmaster-de.png
 
 
 `Trade Me <https://www.trademe.co.nz>`__
@@ -1778,7 +1778,7 @@ Won't allow spaces or single quotes. Maybe other characters as well -
 they do not say up front - but the password they accepted contained lots
 of other special characters.
 
-|TradeMe|
+.. image:: /screenshots/trademe.jpg
 
 
 `TreasuryDirect <https://www.treasurydirect.gov/RS/UN-Display.do>`__
@@ -1788,9 +1788,9 @@ Will allow most passwords longer than 8 characters. Doesn't tell you there is a
 maximum length of 16 characters. Then forces you to type it with an on-screen keyboard
 with no capital letters.
 
-|Treasury1|
+.. image:: /screenshots/treasury1.png
 
-|Treasury2|
+.. image:: /screenshots/treasury2.png
 
 
 `TwinSpires <https://www.twinspires.com/account/register>`__
@@ -1798,7 +1798,7 @@ with no capital letters.
 
 You can gamble on our site. We'll keep your money secure with a 12 character password!
 
-|TwinSpires|
+.. image:: /screenshots/twinspires.png
 
 
 `Ubisoft <https://account.ubisoft.com/en-GB/action/change-password>`__
@@ -1807,7 +1807,7 @@ You can gamble on our site. We'll keep your money secure with a 12 character pas
 Only tells you the rules after submitting and clicking a link to a pop
 up window.
 
-|Ubisoft|
+.. image:: /screenshots/ubisoft.PNG
 
 
 `Unicaja <https://areaprivada.unicajabanco.es/PortalServlet?pag=1533643502465&np=S>`__
@@ -1816,7 +1816,7 @@ up window.
 Username is your national Spanish ID (easy to find).
 Your password must be 6 characters long. You can't type, only select characters from the virtual keyboard
 
-|Unicaja|
+.. image:: /screenshots/unicaja.png
 
 
 `United Parcel Service of America <https://www.ups.com/doapp/signup>`__
@@ -1833,7 +1833,7 @@ Your password must:
 - NOT contain UPS user ID
 - NOT contain email address
 
-|United Parcel Service of America|
+.. image:: /screenshots/ups.png
 
 
 `United States Postal Service <https://reg.usps.com/entreg/secure/ChangePasswordAction_input>`__
@@ -1841,7 +1841,7 @@ Your password must:
 
 Pick from an arbitrary list of symbols, and no repeating characters.
 
-|United States Postal Service|
+.. image:: /screenshots/usps.png
 
 
 `University of California San Diego <https://www.ucsd.edu>`__
@@ -1849,7 +1849,7 @@ Pick from an arbitrary list of symbols, and no repeating characters.
 
 Passwords must be between 8 and **11** characters long!
 
-|University of California San Diego|
+.. image:: /screenshots/ucsd.png
 
 
 `University of Texas at Austin <http://www.utdirect.utexas.edu/utdirect/>`__
@@ -1859,7 +1859,7 @@ Because of the last two rules, which ban dictionary words and any
 variants using symbol substitutions, *neither* of the passwords
 presented in the `xkcd comic <https://xkcd.com/936/>`__ are allowed.
 
-|University of Texas as Austin|
+.. image:: /screenshots/ut-austin.png
 
 
 `University of Western Australia (Pheme) <https://www.pheme.uwa.edu.au/>`__
@@ -1889,9 +1889,9 @@ it doesn't work because the password input field on the *login* page
 
 Passwords must be changed every 6 months.
 
-|University of Western Australia Pheme|
+.. image:: /screenshots/uwa-pheme.png
 
-|University of Western Australia Pheme inspector|
+.. image:: /screenshots/uwa-pheme-inspector.png
 
 
 `University of Windsor <https://uwindsor.teamdynamix.com/TDClient/KB/ArticleDet?ID=46793>`__
@@ -1902,7 +1902,7 @@ characters long, with at least 1 upper case and 1 lower case
 character, at least 1 number, at least 1 special character. Password
 expires every 120 days, and you can't reuse an old one.
 
-|University of Windsor|
+.. image:: /screenshots/uwindsor.png
 
 
 `USAA Bank <https://www.usaa.com/inet/pages/security_take_steps_protect_logon>`__
@@ -1911,7 +1911,7 @@ expires every 120 days, and you can't reuse an old one.
 Password cannot be longer than 12 characters but they don't tell you that until after you try a new password. To make up for this fact they've added dubious additional security features on top of this weak foundation.
 
 
-|USAA|
+.. image:: /screenshots/usaa.png
 
 
 `URSSAF (French employers tax collection service) <https://www.autoentrepreneur.urssaf.fr>`__
@@ -1920,7 +1920,7 @@ When setting a new password:
 Password must be exactly 8 characters, at least 1 letter, at least 1 number, but no special characters.
 
 
-|URSSAF|
+.. image:: /screenshots/urssaf.png
 
 
 `Vancity Credit Union <https://support.vancity.com/17-forget-pac/>`__
@@ -1928,7 +1928,7 @@ Password must be exactly 8 characters, at least 1 letter, at least 1 number, but
 
 Personal Access Code (or PAC–they are too ashamed to call it a password), must be between 5 to 8 digits and cannot start with '0'. (no letters or symbols)
 
-|Vancity Credit Union|
+.. image:: /screenshots/vancity.png
 
 
 `Very.co.uk <https://www.very.co.uk/account/myaccount/changePassword.page>`__
@@ -1937,7 +1937,7 @@ Personal Access Code (or PAC–they are too ashamed to call it a password), must
 Password field allows *only* the listed Special Characters ($ . , ! % ^ \*).
 You're also forced to use both upper, and lower letters, as well as a number.
 
-|Very|
+.. image:: /screenshots/very.png
 
 
 `Vietnam Airlines <https://www.vietnamairlines.com/lotusmiles/enroll-new>`__
@@ -1945,7 +1945,7 @@ You're also forced to use both upper, and lower letters, as well as a number.
 
 ``[[:alnum:]]{6,8}``
 
-|Vietnam Airlines|
+.. image:: /screenshots/vietnamairlines.png
 
 
 `Vio Bank <https://www.viobank.com>`__
@@ -1957,7 +1957,7 @@ The actual list of special characters that are prohibited is correctly enumerate
 
 It took under 5 minutes to find the bug after looking at the source for the first time. This is a bank.
 
-|Viobank|
+.. image:: /screenshots/viobank.png
 
 
 `Virgin Media <https://my.virginmedia.com/forgot-details/reset>`__
@@ -1967,15 +1967,15 @@ Your password needs to be between 8 and 10 characters long, with no
 spaces, and must contain only numbers and letters. The first character
 must be a letter.
 
-|Virgin Media|
+.. image:: /screenshots/virginmedia.jpg
 
 Feb 2020 Update: policy remains the same but the description is hidden
 leaving you to guess the acceptable length/chars.  Users are now left
 with helpful hints after JS validation.
 
-|Virgin Media Too Long|
+.. image:: /screenshots/virginmediatoolong.png
 
-|Virgin Media Invalid|
+.. image:: /screenshots/virginmediainvalid.png
 
 
 `Virgin Mobile <https://myaccount.virginmobileusa.com/primary/my-account-settings-change-pin>`__
@@ -1983,7 +1983,7 @@ with helpful hints after JS validation.
 
 You can only use PIN as your password.
 
-|Virgin Mobile|
+.. image:: /screenshots/virginmobile.png
 
 
 `Virgin Trains <https://www.buytickets.virgintrains.co.uk/buytickets/updatepersonaldetails.aspx#customerDetails>`__
@@ -1993,7 +1993,7 @@ Your password needs to be between 8 and 10 characters long. Previously
 this would silently truncate the password without warning, causing
 confusion when the password wouldn't work.
 
-|Virgin Trains|
+.. image:: /screenshots/virgintrains.jpg
 
 
 `Walmart <https://www.walmart.com/account/signup>`__
@@ -2017,7 +2017,7 @@ Your new password should be different from your previous twenty passwords.
 
 Ok. _Password21!_, it is.
 
-|Walmart|
+.. image:: /screenshots/walmart.png
 
 
 `Wageworks <https://participant.wageworks.com/Home.aspx>`__
@@ -2041,7 +2041,7 @@ Ok. Password21!, it is.
 
 After you request a password reset and you receive an email with instructions and link to reset your password, you are presented with this password reset form. Your password length is limited between 8 and 16 characters. Additionally the form breaks with an error if you use any special characters. The form does not mention anything about special characters. Waze is owned by Google.
 
-|Waze|
+.. image:: /screenshots/waze.png
 
 
 `WeatherBug <https://www.weatherbug.com>`__
@@ -2049,7 +2049,7 @@ After you request a password reset and you receive an email with instructions an
 
 Maximum 16 characters.
 
-|WeatherBug|
+.. image:: /screenshots/weatherbug.png
 
 
 `Wells Fargo <https://oam.wellsfargo.com/oam/access/receiver?dest=MODIFY_PASSWORD>`__
@@ -2057,7 +2057,7 @@ Maximum 16 characters.
 
 Your password must be between 6 and 14 characters.
 
-|Wells Fargo|
+.. image:: /screenshots/wells-fargo.png
 
 
 `WellStar MyChart <https://mychart.wellstar.org/mychart/accesscheck.asp>`__
@@ -2065,7 +2065,7 @@ Your password must be between 6 and 14 characters.
 
 Your password must be between 8 and 20 characters.
 
-|WellStar MyChart|
+.. image:: /screenshots/wellstar-mychart.png
 
 
 `Westpac Live Online Banking <https://banking.westpac.com.au/secure/banking/administration/changepassword>`__
@@ -2073,7 +2073,7 @@ Your password must be between 8 and 20 characters.
 
 6 non-case sensitive characters [exactly].  no blanks, spaces or special characters.
 
-|Westpac Live Online Banking|
+.. image:: /screenshots/westpac.png
 
 
 `Williams-Sonoma <https://secure.williams-sonoma.com/account/updatepassword.html>`__
@@ -2081,7 +2081,7 @@ Your password must be between 8 and 20 characters.
 
 25 maximum characters and disallowing some specials.
 
-|Williams-Sonoma|
+.. image:: /screenshots/williams-sonoma.png
 
 
 `Wells Fargo Identity Theft Protection <https://enhanced.wellsfargoprotection.com/secure/MyProfile.aspx>`__
@@ -2091,7 +2091,7 @@ Your password on an Identity Theft Protection service is limited to
 between 8 and 20 characters. Your username is allowed to be longer than
 your password.
 
-|Wells Fargo Identity Theft Protection|
+.. image:: /screenshots/wells-fargo-identity-theft-protection.png
 
 Xfinity Modem
 ~~~~
@@ -2099,7 +2099,7 @@ Xfinity Modem
 Only letters and numbers are valid. No spaces or special characters.
 Seen on model TG3482G. ARRIS Group, Inc. Firmware: TG3482PC2_3.5p17s1_PROD_sey
 
-|Xfinity Modem|
+.. image:: /screenshots/xfinity-modem.png
 
 
 `Zurich <https://www.zurichlife.ie/bgsi/log_on/password.jsp>`__
@@ -2111,226 +2111,11 @@ The first character must be alphabetic.
 NO spaces.
 The new Password cannot be the same as the last 32 passwords you have used. (they actually store your last 32 passwords)
 
-|Zurich|
+.. image:: /screenshots/zurich.png
 
-.. |Admiral| image:: /screenshots/admiral.png
-.. |ADP| image:: /screenshots/adp.png
-.. |Advanzia| image:: /screenshots/advanzia.png
-.. |Aigues de Barcelona| image:: /screenshots/aigues_barcelona.png
-.. |Air Asia| image:: /screenshots/airaisa.png
-.. |Air France| image:: /screenshots/airfrance.png
-.. |ameli.fr| image:: /screenshots/ameli.fr.png
-.. |American Express| image:: /screenshots/american-express.jpg
-.. |AmeriHealth| image:: /screenshots/amerihealth.png
-.. |AmiAmi| image:: /screenshots/amiami.jpg
-.. |ANZBank| image:: /screenshots/anz_bank.png
-.. |AOL| image:: /screenshots/aol.png
-.. |Apple1| image:: /screenshots/apple1.jpg
-.. |Apple2| image:: /screenshots/apple2.png
-.. |Arbeitnehmeronline| image:: /screenshots/arbeitnehmeronline.png
-.. |Arlo| image:: /screenshots/arlo.png
-.. |asnbank| image:: /screenshots/asnbank.png
-.. |ATT| image:: /screenshots/att.png
-.. |Bank of America| image:: /screenshots/boa.png
-.. |Banca Intesa Serbia| image:: /screenshots/banca_intesa_serbia.png
-.. |Banco Mercantil| image:: /screenshots/banco-mercantil.png
-.. |Bank Millennium| image:: /screenshots/bank-millennium.png
-.. |Battle.net| image:: /screenshots/battlenet.png
-.. |BBVA| image:: /screenshots/bbva.png
-.. |BCV Mobile| image:: /screenshots/bcv_mobile_password.png
-.. |BCV Web| image:: /screenshots/bcv_web.png
-.. |BDO| image:: /screenshots/bdo.png
-.. |Bendigo Bank| image:: /screenshots/bendigo_bank.png
 .. |Best Buy| image:: /screenshots/bestbuy1.png
 .. |Best Buy2| image:: /screenshots/bestbuy2.png
-.. |Blackrock| image:: /screenshots/blackrock.png
-.. |Bloomingdale's| image:: /screenshots/bloomingdales.png
-.. |Blue Cross Blue Shield Massachusetts| image:: /screenshots/bcbs-massachusetts.png
-.. |Boursorama| image:: /screenshots/boursorama.png
-.. |Boligøen| image:: /screenshots/boligoen.jpg
-.. |BMO Bank of Montreal| image:: /screenshots/bmo.jpg
-.. |BMW ConnectedDrive| image:: /screenshots/bmw-connected.PNG
-.. |caf.fr| image:: /screenshots/caf.png
-.. |California DMV| image:: /screenshots/ca-dmv.png
-.. |Canada Revenue Agency| image:: /screenshots/CanadaRevenueAgency.png
-.. |Capital One| image:: /screenshots/capitalone.png
-.. |CenturyLink| image:: /screenshots/centurylink.png
-.. |CIBC| image:: /screenshots/CIBC.png
-.. |Cigna| image:: /screenshots/my.cigna.com.png
-.. |Citi| image:: /screenshots/citi.png
-.. |Chase| image:: /screenshots/chase.jpg
-.. |Chegg1| image:: /screenshots/chegg1.png
-.. |Chegg2| image:: /screenshots/chegg2.png
-.. |Chegg3| image:: /screenshots/chegg3.png
 .. |Comcast| image:: /screenshots/comcast.png
-.. |Commsec| image:: /screenshots/commsec.png
-.. |Copart| image:: /screenshots/copart.png
-.. |Copyright.gov| image:: /screenshots/copyright-gov.png
-.. |Coventry Building Society| image:: /screenshots/coventry-building-society.png
-.. |Credit Agricole| image:: /screenshots/ca-paris.png
-.. |csu.edu.au| image:: /screenshots/csu.edu.au.png
-.. |ca-centrest.fr| image:: /screenshots/ca-centrest.png
-.. |CVent| image:: /screenshots/cvent.png
-.. |CWT| image:: /screenshots/cwt.png
-.. |DBS| image:: /screenshots/dbs.png
-.. |Dell| image:: /screenshots/dell.png
-.. |Deloitte GlobalAdvantage| image:: /screenshots/deloitte.png
-.. |Delta| image:: /screenshots/delta.jpg
-.. |Discovery Benefits 1| image:: /screenshots/discovery-benefits-1.png
-.. |Discovery Benefits 2| image:: /screenshots/discovery-benefits-2.png
-.. |DJI| image:: /screenshots/dji-drones.png
-.. |dnevnik| image:: /screenshots/dnevnik.png
-.. |Easybank| image:: /screenshots/easybank.png
-.. |Easyjet| image:: /screenshots/easyjet.png
-.. |Dutch Tax Authorities| image:: /screenshots/belastingdienst.jpg
-.. |El Corte Ingles| image:: /screenshots/elcorteingles.png
-.. |Electronic Arts| image:: /screenshots/electronic-arts.png
-.. |EllieMae1| image:: /screenshots/elliemae1.png
-.. |EllieMae2| image:: /screenshots/elliemae2.png
-.. |EllieMae3| image:: /screenshots/elliemae3.png
-.. |e-learning (Unipd)| image:: /screenshots/elearning.math.unipd.png
-.. |ETrade| image:: /screenshots/etrade.png
-.. |EON| image:: /screenshots/eon.png
-.. |Faceit| image:: /screenshots/faceit.png
-.. |Fidelity| image:: /screenshots/fidelity.png
-.. |FIS Global| image:: /screenshots/fisglobal.png
-.. |Fundatec| image:: /screenshots/fundatec.png
-.. |Getin Bank| image:: /screenshots/getin.png
-.. |Gebührenfrei MasterCard| image:: /screenshots/gebuhrenfrei-mastercard.png
-.. |Global Entry| image:: /screenshots/global-entry.png
-.. |GoDaddy| image:: /screenshots/godaddy.png
-.. |GoDaddy SFTP| image:: /screenshots/godaddy-sftp.png
-.. |GoFundMe| image:: /screenshots/gofundme.png
-.. |GreenFlag1| image:: /screenshots/green-flag-1.png
-.. |GreenFlag2| image:: /screenshots/green-flag-2.png
-.. |Her Majesty’s Revenue & Customs| image:: /screenshots/tax.service.gov.uk.png
-.. |Hetzner| image:: /screenshots/hetzner.png
-.. |IBM| image:: /screenshots/ibm.png
-.. |IHG| image:: /screenshots/ihg.png
-.. |Inria| image:: /screenshots/inria.png
-.. |INSS| image:: /screenshots/inss.png
-.. |Intel| image:: /screenshots/intel.jpg
-.. |Interactive Brokers| image:: /screenshots/interactive_brokers.png
-.. |ING Bank| image:: /screenshots/ingbank.png
-.. |ING Australia| image:: /screenshots/ingaustralia.png
-.. |ING Romania| image:: /screenshots/ingromania.jpg
-.. |Izly by Crous| image:: /screenshots/izly-by-crous.png
-.. |Jitterbit| image:: /screenshots/jitterbit.png
-.. |Keimyung1| image:: /screenshots/keimyung1.png
-.. |Keimyung2| image:: /screenshots/keimyung2.png
-.. |Keimyung3| image:: /screenshots/keimyung3.png
-.. |Kryterion Webassessor| image:: /screenshots/webassessor.png
-.. |lcl.fr| image:: /screenshots/lcl.png
-.. |LibraryThing| image:: /screenshots/librarything.png
-.. |Lloyds| image:: /screenshots/lloyds.png
-.. |Lowes| image:: /screenshots/lowes.png
-.. |MarketWatch| image:: /screenshots/marketwatch.png
-.. |ME Bank| image:: /screenshots/me-bank.png
-.. |MLB| image:: /screenshots/mlb.png
-.. |Merrill Lynch| image:: /screenshots/merrill-lynch.png
-.. |Maxpreps| image:: /screenshots/maxpreps.png
-.. |MetLife| image:: /screenshots/metlife.png
-.. |Microsoft (work accounts)| image:: /screenshots/microsoftwork.png
-.. |Minecraft| image:: /screenshots/Minecraft.png
-.. |Minnesota UI| image:: /screenshots/minnesota_ui.png
 .. |Mindware| image:: /screenshots/mindware1.png
 .. |Mindware2| image:: /screenshots/mindware2.png
-.. |MKB NetBankár| image:: /screenshots/mkb.png
-.. |Mobi Bike Share| image:: /screenshots/mobibikes.png
-.. |MobileIron| image:: /screenshots/mobileiron.png
-.. |Movistar| image:: /screenshots/movistar.jpg
-.. |Mycanal| image:: /screenshots/mycanal.png
-.. |myswisslife-1| image:: /screenshots/myswisslife-1.jpg
-.. |myswisslife-2| image:: /screenshots/myswisslife-2.jpg
-.. |NBank| image:: /screenshots/nbank.jpg
-.. |NationalBankOfCanada| image:: /screenshots/nbc.png
-.. |NectarApi| image:: /screenshots/nectar-api.png
-.. |Netflix| image:: /screenshots/netflix.png
-.. |Nevada DMV| image:: /screenshots/dmvapp.nv.gov.png
-.. |NVV| image:: /screenshots/nvv.png
-.. |Omnivox| image:: /screenshots/omnivox.png
-.. |Onleihe| image:: /screenshots/onleihe.png
-.. |Oracle| image:: /screenshots/oracle.png
-.. |Origin| image:: /screenshots/origin.png
-.. |PagoMisCuentas| image:: /screenshots/pagomiscuentas.png
-.. |Parnassus| image:: /screenshots/parnassus.png
-.. |PayPal| image:: /screenshots/paypal.png
-.. |Paytm| image:: /screenshots/paytm.png
-.. |PCPartPicker| image:: /screenshots/pcpartpicker.png
-.. |PizzaHut-1| image:: /screenshots/pizzahut1.png
-.. |PizzaHut-2| image:: /screenshots/pizzahut2.png
-.. |PizzaHut-3| image:: /screenshots/pizzahut3.png
-.. |PoleEmploi| image:: /screenshots/pole-emploi.png
-.. |push-tan| image:: /screenshots/push-tan.png
-.. |Premera| image:: /screenshots/premera.png
-.. |Progressive Home by Homesite| image:: /screenshots/progressive-homesite.png
-.. |Raiffeisen Bank Serbia| image:: /screenshots/raiffeisen_bank_srb.png
-.. |Red Hat| image:: /screenshots/redhat.png
-.. |Rediff| image:: /screenshots/rediff.png
-.. |Roll 20| image:: /screenshots/Roll20.png
-.. |Rogers| image:: /screenshots/rogers.png
-.. |Rushmore| image:: /screenshots/rushmore-loan-managment-services.png
-.. |SAP Cloud Appliance Library| image:: /screenshots/sapcal.png
-.. |Scandinavian Airlines| image:: /screenshots/sas.no.png
-.. |Safeway| image:: /screenshots/safeway.png
-.. |Sears| image:: /screenshots/sears.png
-.. |Sharekhan| image:: /screenshots/sharekhan.png
-.. |Singapore Airlines| image:: /screenshots/singaporeairlines.png
-.. |Sky Ticket| image:: /screenshots/sky-ticket.png
-.. |Slovenska sporitelna| image:: /screenshots/slsp.png
-.. |Southwest| image:: /screenshots/southwest.png
-.. |Sparda M 1| image:: /screenshots/sparda-m-1.png
-.. |Sparda M 2| image:: /screenshots/sparda-m-2.png
-.. |Sparda B| image:: /screenshots/sparda-b.png
-.. |Sparkasse Jena| image:: /screenshots/sparkasse_jena.png
-.. |Sprint| image:: /screenshots/sprint.png
-.. |Standard Chartered Bank| image:: /screenshots/standard-chartered-bank.png
-.. |SBI| image:: /screenshots/sbi.png
-.. |SunTrust| image:: /screenshots/suntrust.png
-.. |Synchrony Financial| image:: /screenshots/synchrony.png
-.. |Taco Bell| image:: /screenshots/taco-bell.png
-.. |Tangerine| image:: /screenshots/tangerine.png
-.. |Targobank| image:: /screenshots/targobank.png
-.. |T-Mobile| image:: /screenshots/tmobile.png
-.. |NPTU| image:: /screenshots/nptu.png
-.. |Techcombank| image:: /screenshots/techcombank.png
-.. |MyWorkplace| image:: /screenshots/myworkplace.png
-.. |ThamesWater| image:: /screenshots/ThamesWater.png
-.. |Three-Change| image:: /screenshots/three-change.png
-.. |Three-Reset| image:: /screenshots/three-reset.png
-.. |Ticketmaster.de| image:: /screenshots/ticketmaster-de.png
-.. |TradeMe| image:: /screenshots/trademe.jpg
-.. |Treasury1| image:: /screenshots/treasury1.png
-.. |Treasury2| image:: /screenshots/treasury2.png
-.. |TwinSpires| image:: /screenshots/twinspires.png
-.. |Ubisoft| image:: /screenshots/ubisoft.PNG
-.. |Unicaja| image:: /screenshots/unicaja.png
-.. |United Parcel Service of America| image:: /screenshots/ups.png
-.. |United States Postal Service| image:: /screenshots/usps.png
-.. |University of California San Diego| image:: /screenshots/ucsd.png
-.. |University of Texas as Austin| image:: /screenshots/ut-austin.png
-.. |University of Western Australia Pheme| image:: /screenshots/uwa-pheme.png
-.. |University of Western Australia Pheme inspector| image:: /screenshots/uwa-pheme-inspector.png
-.. |University of Windsor| image:: /screenshots/uwindsor.png
-.. |USAA| image:: /screenshots/usaa.png
-.. |URSSAF| image:: /screenshots/urssaf.png
-.. |Vancity Credit Union| image:: /screenshots/vancity.png
-.. |Very| image:: /screenshots/very.png
-.. |Vietnam Airlines| image:: /screenshots/vietnamairlines.png
-.. |Viobank| image:: /screenshots/viobank.png
-.. |Virgin Media| image:: /screenshots/virginmedia.jpg
-.. |Virgin Media Too Long| image:: /screenshots/virginmediatoolong.png
-.. |Virgin Media Invalid| image:: /screenshots/virginmediainvalid.png
-.. |Virgin Mobile| image:: /screenshots/virginmobile.png
-.. |Virgin Trains| image:: /screenshots/virgintrains.jpg
 .. |WageWorks| image:: /screenshots/wageworks.png
-.. |Walmart| image:: /screenshots/walmart.png
-.. |Waze| image:: /screenshots/waze.png
-.. |WeatherBug| image:: /screenshots/weatherbug.png
-.. |WellStar MyChart| image:: /screenshots/wellstar-mychart.png
-.. |Wells Fargo| image:: /screenshots/wells-fargo.png
-.. |Westpac Live Online Banking| image:: /screenshots/westpac.png
-.. |Williams-Sonoma| image:: /screenshots/williams-sonoma.png
-.. |Wells Fargo Identity Theft Protection| image:: /screenshots/wells-fargo-identity-theft-protection.png
-.. |Xfinity Modem| image:: /screenshots/xfinity-modem.png
-.. |Zurich| image:: /screenshots/zurich.png

--- a/README.rst
+++ b/README.rst
@@ -25,22 +25,24 @@ Table of contents
 
 
 `Admiral <https://myaccount.admiral.com/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Restrict the inclusion of a % character.
 
 |Admiral|
 
+
 `ADP <https://login.adp.nl/selfservice/private/passchange/#/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Forced to change the password during the first login. At least they
 could use proper grammar in their rule list.
 
 |ADP|
 
+
 `Advanzia <https://mein.advanzia.com/icc/assisto/nav/f96/f963b01b-043c-a21a-72e5-fd2ce0f2d5a2.htm#Sicherheit>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Requires at least 6 to a maximum of 12 characters [sic!]
 - Allows only digits and letters without umlauts
@@ -49,39 +51,44 @@ could use proper grammar in their rule list.
 
 |Advanzia|
 
+
 `Air Asia <https://www.airasia.com/member/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Only allows 16 characters in the password input, but does not tell you that.
 Why is your password invalid? It's up to you to find out!
 
 |Air Asia|
 
+
 `Air France <https://www.airfrance.fr/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Between 8 to 12 characters
 - Should contain capital, lowercase letters and numbers
 
 |Air France|
 
+
 `Aigües de Barcelona <https://www.aiguesdebarcelona.cat/oficinaenxarxa/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Between 6 to 10 characters
 - Only letters and numbers, without spaces
 
 |Aigues de Barcelona|
 
+
 `American Express <https://sso.americanexpress.com/SSO/request?request_type=un_createid&ssolang=en_NL&inav=at_sitefooter_register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Sometimes I forget that caps-lock is on, glad it doesn't matter.
 
 |American Express|
 
+
 `Ameli.fr (French national health insurance) <https://www.ameli.fr/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 This was very painful to find a password that works with this one and that I can actually remember (I ended-up using my bank-account number because everything else failed). It took me maybe one hour and I thought I would become crazy (and yes, the session expires frequently while you are actually thinking about a password).
 
@@ -96,7 +103,7 @@ This was very painful to find a password that works with this one and that I can
 
 
 `AmeriHealth <https://www.amerihealth.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Their site says "*All information is kept safe and secure.*" Just not as
 secure as you'd like.
@@ -108,36 +115,40 @@ secure as you'd like.
 
 
 `AmiAmi <https://www.amiami.com/eng/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password needs to be between 6 and 12 characters long, must contain only letters and numbers.
 
 |AmiAmi|
 
+
 `ANZ Bank <https://anz.com.au/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password needs to be between 8 and 16 characters long - no special characters allowed.
 
 |ANZBank|
 
+
 `AOL <https://aol.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Between 8 and 16, so I can't go up to 20.
 
 |AOL|
 
+
 `Apple <https://apple.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Can't contain 3 or more consecutive identical characters, nor can it be more than 32 characters long.
 
 |Apple1|
 |Apple2|
 
+
 `Arbeitnehmeronline <https://www.arbeitnehmeronline.de>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Service for managing employment documents of the German company Datev.
 
@@ -145,8 +156,9 @@ Only the following character categories are allowed: Letters, numbers and this s
 
 |Arbeitnehmeronline|
 
+
 `Arlo <https://arlo.netgear.com/?passwordResetCode>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password contains characters not listed. Therefore, they do not
 match.
@@ -155,29 +167,32 @@ match.
 
 
 `ASN Bank <https://www.asnbank.nl/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password needs to be between 8 and 20 characters long - at least 1 number, 1 lower case letter, 1 upper case letter, 1 special character.
 
 |asnbank|
 
+
 `AT&T <https://www.att.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The only special characters allowed are underscores and hyphens.
 
 |ATT|
 
+
 `Bank of America <https://secure.bankofamerica.com/auth/forgot/reset-entry/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 20 character max and lots of special character restrictions.
 Bank of America - keeping your money safe.
 
 |Bank of America|
 
+
 `Banca Intesa Serbia <https://online.bancaintesa.rs/Retail/home/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Online banking portal of Banca Intesa Serbia has some password restrictions.
 This is the translation of the requirements:
@@ -188,8 +203,9 @@ and maximum number of character repeats is 2.
 
 |Banca Intesa Serbia|
 
+
 `Banco Mercantil <https://www.mercantilbanco.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 8 to 15 chars. No special chars allowed but requires special chars. Also
 requires lowercase, uppercase, and numbers. Consecutive chars are
@@ -198,15 +214,17 @@ tho.
 
 |Banco Mercantil|
 
+
 `Bank Millennium <https://www.bankmillennium.pl/osobiste2/Retail/Login/MulticodeRequest>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords limited to 8 digits.
 
 |Bank Millennium|
 
+
 `Battle.net <https://eu.battle.net/account/creation/en-us/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 8 to 16 characters, at least one number and one letter and last but not least NO special characters, and can't have a password that looks like your username too. Oh, and passwords are NOT case sensitive.
 
@@ -214,8 +232,9 @@ A real time travel adventure through the password rules of 2005!
 
 |Battle.net|
 
+
 `BBVA <https://web.bbva.es/public.html?v=20190510#public/hazte-cliente>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Username is your national ID (easy to find) and your password must have up to **6** alphanumeric characters only.
 
@@ -223,8 +242,9 @@ For a bank account with all your money in one of the largest financial instituti
 
 |BBVA|
 
+
 `BCV <https://www.bcv.ch/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Username is randomly generated, example: 'H2487414'. The password must have **6** digits only.
 
@@ -233,15 +253,17 @@ Password can only be changed from the mobile application:
 |BCV Web|
 |BCV Mobile|
 
+
 `Bendigo Bank <https://banking.bendigobank.com.au/Logon/passwd.page>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 **Exactly** eight characters.
 
 |Bendigo Bank|
 
+
 `BDO <https://www.bdo.com.ph/personal>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Please nominate a password which contains UPPERCASE, lowercase, numbers and symbols.
 Password should not be the same as the user ID.
@@ -249,8 +271,9 @@ Avoid using consecutive characters such (ex. abc, DEF, 678) and invalid characte
 
 |BDO|
 
+
 `Best Buy <https://www-ssl.bestbuy.com/identity/changePassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You can enter whatever password you like! But you probably don't want to
 make it too long, because you'll break us and you'll never be able to
@@ -259,38 +282,43 @@ login again.
 | |Best Buy|
 | |Best Buy2|
 
+
 `Blackrock <https://nge01.bnymellon.com/NextGenV4/dflt/Login.blk>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 They force you to enter a password that has 8, 9, or 10 characters, then
 they lecture you on how to create a strong password.
 
 |Blackrock|
 
+
 `Bloomingdale's <https://www.bloomingdales.com/account/createaccount?cm_sp=my_account-_-sign_in-_-create_account>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 16 characters maximum, no ``.`` ``,`` ``-`` ``|`` ``/`` ``=`` or ``_`` allowed.
 
 |Bloomingdale's|
 
+
 `Blue Cross Blue Shield Massachusetts <https://www.bluecrossma.com/wps/portal/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 16 maximum and no special characters. Protecting your US healthcare
 information.
 
 |Blue Cross Blue Shield Massachusetts|
 
+
 `BMO Bank of Montreal <https://www1.bmo.com/onlinebanking/cgi-bin/netbnx/NBmain?product=5>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password requires at least one special character but disallows backtick `````, backslash ``\``, vertical bar ``|``, and underscore ``_``.
 
 |BMO Bank of Montreal|
 
+
 `BMW ConnectedDrive <https://www.bmw-connecteddrive.co.uk/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Although the prompt suggests good things, after many failed attempts to
 set a new password, it turns out you can ONLY use the special characters
@@ -298,15 +326,17 @@ shown in the prompt
 
 |BMW ConnectedDrive|
 
+
 `Boligøen (Danish resident renting bureau) <https://boligøen.dk/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Red text: "Your password has to be at least 6 characters, but NOT over 20 characters."
 
 |Boligøen|
 
+
 `Boursorama <https://www.boursorama.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 "To ensure the highest level of security, your password must
 have... 8 digits". And it must be entered using a funny keypad
@@ -314,15 +344,17 @@ with the digits in the wrong order.
 
 |Boursorama|
 
+
 `CAF (French Family Allowance Fund) <https://www.caf.fr/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You have to enter your 8-digit password using this Frenchy keypad.
 
 |caf.fr|
 
+
 `California Department of Motor Vehicles <https://www.dmv.ca.gov/FIM/sps/uscfed/usc/self/account/create>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 They also prohibit pasting into the password field by using a JavaScript
 ``alert()`` whenever you right-click or press the ``Ctrl`` button, so
@@ -330,8 +362,9 @@ you can't use a password manager.
 
 |California DMV|
 
+
 `Canada Revenue Agency <https://cms-sgj.cra-arc.gc.ca/gol-ged/awsc/cms/registration/start>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password checklist:
 
@@ -346,8 +379,9 @@ Password checklist:
 
 |Canada Revenue Agency|
 
+
 `Capital One <https://myaccounts.capitalone.com/security/changePassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - May only use the following characters: Aa-Zz 0-9 - _ . / \\ @ $ * & ! #
 - No spaces
@@ -356,30 +390,33 @@ Password checklist:
 
 
 `CenturyLink <https://eam.centurylink.com/eam/login.do>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 So many bad ideas: a low maximum length, requiring six specific character types while not accepting common symbols,
 plus a weird restriction that makes random generation harder.
 
 |CenturyLink|
 
+
 `Credit Agricole <https://www.credit-agricole.fr/ca-paris/particulier/acceder-a-mes-comptes.html0>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 * Login is a predefined 11 digits long identifier that you can not change
 * Password is a 6 digits long identifier that you need to input using your mouse
 
 |Credit Agricole|
 
+
 `Charles Sturt University <https://www.csu.edu.au/division/dit/services/services/access-and-logins/password-management>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Prevents spaces and a set list of characters, limits to 30 characters and can only change your password twice per day.
 
 |csu.edu.au|
 
+
 `Chase Bank <https://secure01a.chase.com/web/auth/dashboard>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 * Can't use any special characters except ! # $ % + / = @ ~
 * Max length restriction (32 characters).
@@ -388,8 +425,9 @@ Prevents spaces and a set list of characters, limits to 30 characters and can on
 
 |Chase|
 
+
 `Chegg <https://www.chegg.com/auth?action=signup>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Here are the (only fairly poor) rules for a new password. Enter 64 character password that matches all the rules (notice no rules on maximum length). That password you entered looks good! But we didn't change it. And your old password doesn't work. Or the new one. ¯\\\_(ツ)\_/¯
 
@@ -397,28 +435,32 @@ Here are the (only fairly poor) rules for a new password. Enter 64 character pas
 |Chegg2|
 |Chegg3|
 
+
 `Canadian Imperial Bank of Commerce <https://www.cibconline.cibc.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Letters and numbers only, no symbols. Also an undocumented maximum of 12 characters!
 
 |CIBC|
 
+
 `Comcast <https://customer.xfinity.com/#/settings/security/xfinity-access/password>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password should be difficult to guess as long as it's not over 16
 characters long.
 
+
 `Cigna <https://my.cigna.com/web/secure/my/profile/change-password>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 A max of 12 characters... Can't handle most symbols (only 5 supported). At least they have two factor auth via email or sms * *sigh* *
 
 |Cigna|
 
+
 `Citi <https://www.citi.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 * Password is case-insensitive
 * Can't use ANY special characters (although, adding special characters increases the "password strength" meter?!)
@@ -427,15 +469,17 @@ A max of 12 characters... Can't handle most symbols (only 5 supported). At least
 
 |Citi|
 
+
 `Commsec <https://www2.commsec.com.au/selfservice/resetpassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Another financial institution with short password requirements. They also block pasting in to the field, making it a pain to use a password manager.
 
 |Commsec|
 
+
 `Copart <https://copart.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Copart: "The security of our members is extremely imporant to us."
 
@@ -443,29 +487,33 @@ Also Copart: "We're gonna need you to keep your password between 5-10 characters
 
 |Copart|
 
+
 `Copyright.gov <https://www.copyright.gov/eco/help-password-userid.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 I wonder if they cooperate with NSA to enforce the password rules.
 
 |Copyright.gov|
 
+
 `Coventry Building Society <https://www.coventrybuildingsociety.co.uk/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password has to be between 6 and 10 characters, can't contain any punctuation and you have to give characters from it on the phone to confirm identity.
 
 |Coventry Building Society|
 
+
 `Crédit Agricole Centre-Est <https://www.ca-centrest.fr>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You have to enter your 6-digit password using this Frenchy keypad.
 
 |ca-centrest.fr|
 
+
 `CVent <https://www.cvent.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password Rules
 
@@ -474,8 +522,9 @@ Password Rules
 
 |CVent|
 
+
 `CWT Business Travel Management Company <https://travel.mycwt.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password:
 - 8 to 32 characters long
@@ -485,15 +534,17 @@ Password:
 
 |CWT|
 
+
 `DBS Bank (Singapore) <https://internet-banking.dbs.com.sg/IB/Welcome>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 ``[[:digit:]]{6,8}``
 
 |DBS|
 
+
 `Dell <https://www.dell.com/Identity/global/LoginOrRegister>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Okay at least 6, that's alright i guess.
 Oh at least one number and one letter, bit dumb but hey not that dumb.
@@ -502,23 +553,26 @@ But hiding the fact that it has a max of 20, now THAT is dumb!
 
 |Dell|
 
+
 `Deloitte GlobalAdvantage <http://www.ga.deloitte.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Rules that are completely arbitrary that basically make all safe passwords wrong,
 instead forcing pseudo-safe password combinations.
 
 |Deloitte GlobalAdvantage|
 
+
 `Delta <https://www.delta.com/us/en/advisories/other-alerts/password-security>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 It's a good thing they don't store personal information such as your passport number... oh wait.
 
 |Delta|
 
+
 `Discovery Benefits <https://benefitslogin.discoverybenefits.com/Login.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Requires at least one symbol, but must be one of `! @ # $ % & * ?`, and also
 has an unstated max length of 20 characters.
@@ -526,8 +580,9 @@ has an unstated max length of 20 characters.
 |Discovery Benefits 1|
 |Discovery Benefits 2|
 
+
 `DJI <https://account.dji.com/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The symbol `\\` is banned without a notice, it'll probably escape whatever you'll put in, just why...
 
@@ -535,7 +590,7 @@ The symbol `\\` is banned without a notice, it'll probably escape whatever you'l
 
 
 `Dnevnik.ru <https://login.dnevnik.ru/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Silently (sic!) trim password to 30 symbols.
 
@@ -545,7 +600,7 @@ That causes the stupid case when you could successfully registrate an account wi
 
 
 `Dutch Tax Authorities (Belastingdienst) <https://www.belastingdienst.nl/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 At least 8 and at most 25 characters, of which at least 3 of the characters were not used in the previous password.
 No more than 3 of the same characters.
@@ -556,8 +611,9 @@ It's not like hashing passwords is a thing or something.
 
 |Dutch Tax Authorities|
 
+
 `Easybank (Austrian direct bank) <https://www.easybank.at/de/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - At least 8 and at most 16 (!) characters
 - **Must start with 5 digits (do we really want to know what's going on there?)**
@@ -568,15 +624,17 @@ It's not like hashing passwords is a thing or something.
 
 |Easybank|
 
+
 `Easyjet <https://www.easyjet.com/en>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 No more than 20 characters, use any symbols you like... Oh except #, &, +, or space of course.
 
 |Easyjet|
 
+
 `El Corte Ingles <https://www.elcorteingles.es/profile2/profile/registration/registroCliente.jsp?tiendaId=moonshine&pag_regreso=www.elcorteingles.es>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Min 6 and max 8 characters for password! Can't contain anything
 different than letters and numbers. Apart, the email address must have
@@ -584,8 +642,9 @@ at least 8 characters (sorry million dollar domain owners! :D)
 
 |El Corte Ingles|
 
+
 `E-learning (Unipd) <https://elearning.studenti.math.unipd.it/authenticate/change_password/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Exactly 8 characters for password! There must be at least 1 lowercase
 letter, at least 1 uppercase letter, at least 1 number and at least 1
@@ -593,15 +652,17 @@ letter, at least 1 uppercase letter, at least 1 number and at least 1
 
 |e-learning (Unipd)|
 
+
 `Electronic Arts (EA) <https://www.ea.com/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must be 8 - 16 characters, and include at least one lowercase letter, one uppercase letter, and a number.
 
 |Electronic Arts|
 
+
 `EllieMae Access <https://access.elliemae.com/home>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Must reset password every 6 months and password requirements are not displayed _anywhere_.
 Reset uses a Security Question, and you have to choose from a list of 5.
@@ -610,8 +671,9 @@ Reset uses a Security Question, and you have to choose from a list of 5.
 |EllieMae2|
 |EllieMae3|
 
+
 `E-Trade <https://us.etrade.com/e/t/user/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Causes:
 
@@ -625,15 +687,17 @@ You must reduce your password to 26 characters in order to login with a token.
 
 |ETrade|
 
+
 `FACE IT Ltd. (Faceit) <https://www.faceit.com/en/signup>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must be 6 - 20 characters. No special characters or numbers required.
 
 |Faceit|
 
+
 `Fidelity <https://fps.fidelity.com/ftgw/Fps/Fidelity/RtlCust/ChangePIN/Init>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 No more than 20 characters and leave out characters commonly used by
 programmers. We don't want you to hack the mainframe.
@@ -642,7 +706,7 @@ programmers. We don't want you to hack the mainframe.
 
 
 `Fidelity National Information Services <https://www.fisglobal.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 White label online banking provider. Typically appears as `BANK.ibanking-services.com` or `BANK.ebanking-services.com`. If your small local bank has a crappy online banking experience, these guys probably provide it.
 
@@ -650,29 +714,33 @@ White label online banking provider. Typically appears as `BANK.ibanking-service
 
 |FIS Global|
 
+
 `EON <https://www.eonenergy.com/for-your-home/your-account/forgotten-password/non-link-reset/Reset>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 By the time I'd finished reading the rules I've forgotten all of them.
 
 |EON|
 
+
 `Fundatec <http://www.fundatec.org.br/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Must be exactly 6 alphanumeric characters, does not show special characters are not allowed, username is your social security number (easily searchable) and the form is sent over plain HTTP. Did I mention this company applies college entrance exams for **Computer Science** nationwide in Brazil?
 
 |Fundatec|
 
+
 `Gebührenfrei MasterCard <https://www.gebuhrenfrei.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The new password can only have 6-12 characters. It *may* contain letters, numbers and a fixed set of special characters.
 
 |Gebührenfrei MasterCard|
 
+
 `Getin Bank <https://secure.getinbank.pl/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The new password should contain at least 10 and a maximum of 20 characters.
 The password must contain at least one upper case letter, one lower case
@@ -681,30 +749,34 @@ characters, special characters ``&<'"`` or spaces.
 
 |Getin Bank|
 
+
 `Global Entry <https://goes-app.cbp.dhs.gov/goes/PasswordChangePreAction.do>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 "Our duties are wide-ranging, and our goal is clear - keeping America
 safe."
 
 |Global Entry|
 
+
 `GoDaddy <https://www.godaddy.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Some characters are **too** special.
 
 |GoDaddy|
 
+
 `GoDaddy SFTP <https://www.godaddy.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Max 14 characters for the most important password in your shared hosting environment.
 
 |GoDaddy SFTP|
 
+
 `GoFundMe <https://www.gofundme.com/sign-up>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - At least one uppercase and one lowercase letter
 - At least one number and one special symbol
@@ -712,8 +784,9 @@ Max 14 characters for the most important password in your shared hosting environ
 
 |GoFundMe|
 
+
 `Green Flag <https://www.greenflag.com//>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - 8 to 10 characters
 - No special characters
@@ -721,15 +794,17 @@ Max 14 characters for the most important password in your shared hosting environ
 |GreenFlag1|
 |GreenFlag2|
 
+
 `Her Majesty’s Revenue & Customs (UK Tax) <https://www.tax.service.gov.uk/government-gateway-registration-frontend?accountType=individual&continue=%2Fpersonal-account%2Fdo-uplift&origin=unknown>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 We store basically all of your data, but we can't store your password.
 
 |Her Majesty’s Revenue & Customs|
 
+
 `Hetzner <https://hetzner.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - 8 or more characters
 - At least one uppercase and one lowercase letter
@@ -743,23 +818,26 @@ You can't use ``&<>'"\|´```, spaces and any other non-ascii character.
 
 |Hetzner|
 
+
 `IBM <https://www.ibm.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password cannot be longer then 31 characters.
 Spaces, ?, ../, curly braces and double byte character not allowed
 
 |IBM|
 
+
 `IHG <https://www.ihg.com/rewardsclub/us/en/join/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 4, yes 4, digits only.
 
 |IHG|
 
+
 `ING a dutch bank in almost 50 countries <https://www.ing.nl/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Max 20 characters, must have one number, one upper case character and one lower case character.
 You can only use certain special characters.
@@ -770,9 +848,8 @@ this was march 2018.
 |ING Bank|
 
 
-
 `ING Australia <https://www.ing.com.au/securebanking/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 4 numeric digits.
 "Added security" by randomising the positions on the keypad. Must be clicked.
@@ -781,7 +858,7 @@ this was march 2018.
 
 
 `ING Romania's Internet Banking Portal <https://www.homebank.ro/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 No more, no less than 5 digits. This is the password you use to log in and to confirm
 online transactions. They used to have "normal" passwords and they forced everybody to
@@ -792,7 +869,7 @@ OK, because everybody has 2FA.
 
 
 `Inria <https://vpn1-roc.national.inria.fr/+CSCOE+/logon.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 This is the account for those who work at `Inria
 <https://www.inria.fr/>` "the French national research institute for
@@ -816,8 +893,9 @@ the other ones.
 
 |Inria|
 
+
 `INSS (Instituto Nacional do Seguro Social) <https://www.inss.gov.br/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The National Social Security Institute (INSS) is an autarchy of the Government of Brazil linked to the Ministry of Economy that receives the contributions for the maintenance of the General Social Security System, responsible for the payment of pensions, maternity pay, death pay, sickness pay, accident pay, seclusion pay and other benefits for those who acquire the right to these benefits as provided by law. The INSS works with Dataprev, a technology company that processes all Social Security data. But:
 
@@ -827,13 +905,15 @@ The National Social Security Institute (INSS) is an autarchy of the Government o
 
 |INSS|
 
+
 `Intel <https://www-ssl.intel.com/content/www/uk/en/my-intel/reseller-sign-in-help.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 |Intel|
 
+
 `Interactive Brokers <https://ndcdyn.interactivebrokers.com/Universal/servlet/Application.ApplicationSelector>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Usual dumb password restrictions, but this one has incredibly dumb **username**
 restrictions too:
@@ -855,8 +935,9 @@ restrictions too:
 
 |Interactive Brokers|
 
+
 `Izly by Crous <https://mon-espace.izly.fr/Home/Logon>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Izly by Crous is an **imposed** French payment service for the
 university. You can't pay your daily meal without that because yeah you
@@ -872,8 +953,9 @@ Oh and also look we got pages **NOT TRANSLATED IN FRENCH** because duh.
 
 |Izly by Crous|
 
+
 `Lloyds Bank <https://online.lloydsbank.co.uk/personal/logon/login.jsp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Max 15 characters, min 8. You cannot use **ANY** special characters -
 alpha-numerics only. This amazingly terrible password policy combines
@@ -883,8 +965,9 @@ This phrase has similar alpha-numeric restrictions applied.
 
 |Lloyds|
 
+
 `Jitterbit <https://www.jitterbit.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 While not the dumbest password rule, still dumb.
 
@@ -894,8 +977,9 @@ While not the dumbest password rule, still dumb.
 
 |Jitterbit|
 
+
 `Keimyung University <https://sso.kmu.ac.kr/kmusso/ext/edward/login_form.do/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Okay, doesn't looks that hard... But wait, there are hidden rules!
 
@@ -906,15 +990,17 @@ Okay, doesn't looks that hard... But wait, there are hidden rules!
 |Keimyung2|
 |Keimyung3|
 
+
 `Kryterion Webassessor <https://webassessor.com/googlecloud>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 I was quite suprised to see this when I was registering for my Google Professional Cloud **Security** Engineer certification. Nice part is that they **don't allow quotes** as special character, so I assume there possibly might be some other issues on their backends. :-)
 
 |Kryterion Webassessor|
 
+
 `LCL <https://www.lcl.fr>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You have to enter your 6-digit password using this Frenchy keypad.
 
@@ -922,14 +1008,15 @@ You have to enter your 6-digit password using this Frenchy keypad.
 
 
 `LibraryThing <https://www.librarything.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 "Your password cannot be longer than 20 characters"
 
 |LibraryThing|
 
+
 `Lowes <https://www.lowes.com/mylowes/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Be 8 to 12 characters in length
 - Include at least 1 letter and 1 number
@@ -938,8 +1025,9 @@ You have to enter your 6-digit password using this Frenchy keypad.
 
 |Lowes|
 
+
 `MarketWatch <http://www.marketwatch.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Cannot be longer than 15 characters.
 - Must contain one number.
@@ -947,14 +1035,16 @@ You have to enter your 6-digit password using this Frenchy keypad.
 
 |MarketWatch|
 
+
 `Maxpreps <http://www.maxpreps.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 `Natalie Weiner <https://twitter.com/natalieweiner/status/1034533245839450113?s=19>`__
  can't sign in because her's lastname is offensive language for the website
 |Maxpreps|
 
+
 `ME Bank <https://ib.mebank.com.au/authR5/ib/login.jsp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Must be all numerals.
 - Be 7 to 20 digits.
@@ -966,8 +1056,9 @@ You have to enter your 6-digit password using this Frenchy keypad.
 
 |ME Bank|
 
+
 `Merrill Lynch <https://www.benefits.ml.com/Core/User/ChangePassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords must be between 8 and 20 characters, and some special
 characters are allowed. Users with randomly-generated passwords may find
@@ -976,8 +1067,9 @@ password safe.
 
 |Merrill Lynch|
 
+
 `Major League Baseball <https://securea.mlb.com/enterworkflow.do?flowId=registration.connect.wizard&c_id=mlb&template=mobile&forwardUrl=https://www.mlb.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 When creating a new account they enforce some password rules like: length must be
 between 8 and 15 characters and there must be one upper case, one lower case letter
@@ -985,16 +1077,18 @@ and one number.
 
 |MLB|
 
+
 `MetLife <https://online.metlife.com/edge/web/profile/viewProfile?show=profileSettings>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 Max length of 20 characters, no special characters allowed.
 Pasting into the second password field is disabled even with
 the Chrome extension Don't Fuck With Paste.
 
 |MetLife|
 
+
 `Microsoft (work accounts) <https://account.activedirectory.windowsazure.com/ChangePassword.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 What doesn't seem to be a problem for personal accounts, is for work
 accounts from Microsoft (e.g. Office 365 etc.).
@@ -1008,8 +1102,9 @@ supposedly "spaces".
 
 |Microsoft (work accounts)|
 
+
 `Mindware <https://secure.mindware.orientaltrading.com/web/login/createUser>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You "*may use special characters*", but only some of them - and we won't
 necessarily tell you which ones.
@@ -1017,21 +1112,24 @@ necessarily tell you which ones.
 | |Mindware|
 | |Mindware|
 
+
 `Minecraft <https://my.minecraft.net>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 Using a 16 character password seems to work. Everything else above does not always work.
 Also, passwords that are too long are still changed, so you have to reset them by email.
 
 |Minecraft|
 
+
 `Minnesota Unemployment Insurance <https://uimn.org>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 Locked to *exactly* 6 chars, alphanumeric only, not special chars.
 
 |Minnesota UI|
 
+
 `MKB NetBankár <https://www.mkbnetbankar.hu/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 | It only accepts lowercase letters, uppercase letters and numbers (any
   other character counts as forbidden character).
@@ -1048,8 +1146,9 @@ Locked to *exactly* 6 chars, alphanumeric only, not special chars.
 
 |MKB NetBankár|
 
+
 `Mobi Bike Share <https://www.mobibikes.ca/en/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your PIN (which is the password you use to login, which lets you, say, buy hundreds of dollars worth of bike-share subscriptions off the saved credit card) must be four numeric digits. Helpfully, they even give you an example of a PIN: *1234*.
 
@@ -1057,7 +1156,7 @@ Your PIN (which is the password you use to login, which lets you, say, buy hundr
 
 
 `Movistar <https://www.movistar.es/particulares/Privada/Registro/?url=%2Fmimovistar-cliente%2Fes-es%2Fparticulares%2Fregistro%2FdatosUsuario.html&>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Min 7 and max 8 characters for password! Also to be different than the
 username: the user name is automatically generated and is based on the
@@ -1067,8 +1166,9 @@ Has been that way for more than 10 years.
 
 |MobileIron|
 
+
 `MobileIron MDM <https://www.mobileiron.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You can't make this up - no dictionary words, no more than 2 repeating
 characters, no alphabetic sequences, no whitespace, 3 character sets,
@@ -1077,8 +1177,9 @@ maximum of 32 characters.
 
 |Movistar|
 
+
 `Mycanal <https://www.mycanal.fr/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Minimum of 8 characters
 - Contain at least 1 uppercase character or 1 number
@@ -1086,23 +1187,26 @@ maximum of 32 characters.
 
 |Mycanal|
 
+
 `MySwissLife <https://myswisslife.fr/#/login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 User ID *has to* be 8 characters exactly, password *has to be* 8 characters and numbers only.
 
 |myswisslife-1|
 |myswisslife-2|
 
+
 `NBank <https://www.nbank.de/Service/Kundenportal/Zugang-zum-Kundenportal/index.jsp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 User ID *has to* contain special characters, password *may not* contain (basically) any special characters.
 
 |NBank|
 
+
 `NBC (National Bank of Canada) <https://www.nbc.ca>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Password length must be 8 to 25 characters
 - Password must contain at least one lower letter (any position)
@@ -1111,8 +1215,10 @@ User ID *has to* contain special characters, password *may not* contain (basical
 - Copy/paste is not allowed when trying to set a new password
 
 |NationalBankOfCanada|
+
+
 `Nectar API <https://api.nectar.com/oauth/authorize>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The Nectar website allows strong passwords.
 However, when trying to link my Sainsbury's account, I found the API has different ideas...
@@ -1120,6 +1226,7 @@ However, when trying to link my Sainsbury's account, I found the API has differe
 - Password field length capped to 16 characters
 
 |NectarApi|
+
 
 `Netflix <https://www.netflix.com/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1137,8 +1244,9 @@ There is no apparent reason for disallowing the tilde but allowing all other spe
 Luckily, that rule is not enforced at all.
 It seems to be only written down to irritate customers.
 
+
 `Nevada DMV <https://dmvnv.com/onlineservices.htm>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Password length must be exactly 8 characters in length
 - Password must contain at least one letter (any position)
@@ -1148,85 +1256,94 @@ It seems to be only written down to irritate customers.
 
 |Nevada DMV|
 
+
 `NVV (Nordhessische VerkehrsVerbund) <https://nvv.mobilesticket.de/ticketportal/register.jsf>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 |NVV|
 
 Password length must be 4 to 10 characters with only a few special characters allowed.
 
+
 `Omnivox <https://cegep-ste-foy.omnivox.ca/Login/Account/Login>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password length must be 8 to 20 characters long with lower case characters and numbers only.
 
 |Omnivox|
 
+
 `Onleihe <https://www4.onleihe.de/essen/frontend/myBib,0-0-0-100-0-0-0-0-0-0-0.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password is your birthday in format ddmmyyyy. Users are not allowed to change their passwords
 
 |Onleihe|
 
 
-
 `Oracle <https://profile.oracle.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 *Should not* or *must not*? RFC 2119 may want a word with you.
 
 
 |Oracle|
 
+
 `Origin <https://www.origin.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be between 8 and 16 characters long
 
 |Origin|
 
+
 `PagoMisCuentas <https://www.pagomiscuentas.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be between 8 and 15 alphanumeric characters, and have
 at least one uppercase and one lowercase letter.
 
 |PagoMisCuentas|
 
+
 `Parnassus Investments <https://www.parnassus.com/your-account/newaccount/open-account-intro/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 A site responsible for protecting your investments limiting you to a
 four character range with a bunch of other stupid rules? Shocking.
 
 |Parnassus|
 
+
 `PayPal <https://www.paypal.com/welcome/signup>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Must be between 8 and 20 characters, no spaces, uppercase and lowercase, one symbol...
 
 |PayPal|
 
+
 `Paytm <https://paytm.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be between 5 and 15 characters. Also, spaces don't count
 as characters.
 
 |Paytm|
 
+
 `PCPartPicker <https://pcpartpicker.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 There are no rules for passwords. Passwords can be any length (including one character)
 of any complexity. No password change confirmation emails are sent.
 
 |PCPartPicker|
 
+
 `PizzaHut <https://www.pizzahut.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords must be greater than 6 characters, and have an arbitrary set of rules we don't tell you about until after you try to set your password.
 
@@ -1234,8 +1351,9 @@ Passwords must be greater than 6 characters, and have an arbitrary set of rules 
 |PizzaHut-2|
 |PizzaHut-3|
 
+
 `Pole-Emploi <https://www.pole-emploi.fr/accueil/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must contain at least one letter, one number and one character from ``&-_@*%=.,;:!?`` only.
 It rejected passwords generated by pass, while accepting ``p@ssw0rd!``...
@@ -1251,8 +1369,9 @@ Password must contain 8-30 characters, including one letter and one number.
 
 |Premera|
 
+
 `Progressive Home by Homesite <https://progressivedirect.homesite.com/OnlineServicing/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be a minimum of 8 characters.
 Passwords must have one lowercase character.
@@ -1268,8 +1387,9 @@ However, when you log in, it only allows passwords up to 12 characters in length
 
 |Progressive Home by Homesite|
 
+
 `Raiffeisen Bank Serbia <https://rol.raiffeisenbank.rs/Retail/home/login/>`__
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 There are a couple of password limitations when creating a new account on
 Raiffeisen Bank Serbia on-line banking portal. Password length is limited to
@@ -1279,16 +1399,18 @@ and first character must be a letter. Oh... And, no special characters!
 
 |Raiffeisen Bank Serbia|
 
+
 `Red Hat <https://www.redhat.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Symbols. You keep using that word. I don't think it means what you think
 it means.
 
 |Red Hat|
 
+
 `Rediff <https://www.rediff.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 A maximum password length of 12. The hidden requirements are:
 
@@ -1299,8 +1421,9 @@ A maximum password length of 12. The hidden requirements are:
 
 |Rediff|
 
+
 `Rogers <https://rogers.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 I can only use 4 special characters?
 
@@ -1311,29 +1434,33 @@ Password guidelines
 
 |Rogers|
 
+
 `Roll 20 <https://app.roll20.net/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your new password must be at least 4 characters long and no longer than 40 characters. Your password was not changed.
 
 |Roll 20|
 
+
 `Rushmore Loan Management Services <https://rushmore.customercarenet.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Hmmm.. why are they afraid of double and single quotes in my passwords?
 
 |Rushmore|
 
+
 `SAP Cloud Appliance Library <https://cal.sap.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords between 8 and 9 characters are the best.
 
 |SAP Cloud Appliance Library|
 
+
 `Scandinavian Airlines <https://www.flysas.com/us-en/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The password rules itself is fine, but, it doesn't inform about the max length of the password.
 Their max length is 14 characters, so even if you enter a password of 42 chars, you can login with the first 14 of it.
@@ -1350,15 +1477,17 @@ Answer form SAS customer service::
 
 |Scandinavian Airlines|
 
+
 `Safeway <https://shop.safeway.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords limited to 8-12 characters.
 
 |Safeway|
 
+
 `Sears <https://www.sears.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 "cAsE sensitive, no spaces, ! or ?
 8 characters min - 1 letter, 1 number
@@ -1367,23 +1496,26 @@ Cannot be or contain your username or email address"
 
 |Sears|
 
+
 `Sharekhan <https://www.sharekhan.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - At least 8 characters.
 - At most 12 characters.
 
 |Sharekhan|
 
+
 `Singapore Airlines <https://www.singaporeair.com/en_UK/ppsclub-krisflyer/registration-form/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 ``/[0-9]{6}/``
 
 |Singapore Airlines|
 
+
 `Sky Ticket <https://skyticket.sky.de/home/login/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Sky is a german pay-TV provider with over 23 million subscribed users worldwide. They also have an online streaming service called "Sky Ticket".
 
@@ -1391,15 +1523,17 @@ You can only set a **4 digit long PIN** with no option for two-factor authentica
 
 |Sky Ticket|
 
+
 `Slovenska sporitelna <https://mysecurity.slsp.sk/zmena-hesla>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Slovenska sporitelna is the biggest bank in Slovakia. Despite pretty new version of the internet banking (rolled out in 2018), their password policy restricts password to be 16 characters long at most and prohibits any special characters.
 
 |Slovenska sporitelna|
 
+
 `Sparda-Bank <https://banking.sparda-m.de/spm/?institut=7009>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Sparda is a group of German banks. They all use the same login form (except for Sparda-Bank Berlin, see below). Their equivalent of a password is called *Online-PIN*. As the name implies, only digits are allowed. (*Zifferneingabe* means "digit input"; it opens an on-screen number pad widget.)
 
@@ -1418,16 +1552,18 @@ The odd one out is Sparda-Bank Berlin, which has different rules:
 
 |Sparda B|
 
+
 `Southwest <https://https://www.southwest.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be between 8 and 16 characters in length and include at least one uppercase letter
 and one number. Certain special characters are also allowed, but the first character of the password must be alphanumeric.
 
 |Southwest|
 
+
 `Sparkasse <https://s-jena.de>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 „Sparkasse“ is a group of banks which is pretty popular in Germany. It
 calls its passwords „PIN“ („persönliche Identifikations-Nummer“ —
@@ -1466,15 +1602,17 @@ diffrent:
 - At least one special character
 - Upper- and lowercase letters
 
+
 `Sprint <https://mysprint.sprint.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Sprint "upgraded" their security and disallow special characters.
 
 |Sprint|
 
+
 `State Bank of India (Foreign Travel Card) <https://prepaid.onlinesbi.com/SBICMS/jsp/Portals/jsp/foreignCard.jsp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 State Bank of India is the largest government operated bank in India.
 They offer "travel" prepaid cards for foreign currencies, this is for
@@ -1491,44 +1629,50 @@ Your password must:
 
 |SBI|
 
+
 `Standard Chartered Bank <https://www.sc.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 - Between 8 to 16 characters
 - Only letters and/or numbers
 
 |Standard Chartered Bank|
 
+
 `SunTrust <https://www.suntrust.com/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 At least there are a variety of special characters to choose from.
 
 |SunTrust|
 
+
 `Synchrony Financial <https://consumercenter.mysynchrony.com/consumercenter/securityinfoaction_change_password_review_cancel.do>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Financial services - where we don't allow you to create the strongest
 password possible.
 
 |Synchrony Financial|
 
+
 `Taco Bell <https://www.tacobell.com/login/pw/change?token=***>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password may include special characters, except for #.
 
 |Taco Bell|
 
+
 `Tangerine <https://www.tangerine.ca>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your PIN can only contain numbers and must be between 4 and 6 numbers.
 |Tangerine|
 
+
 `Targobank <https://www.targobank.de/de/banque/change_password/UA_Gestion_ChPw.aspx/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must:
 
@@ -1543,15 +1687,17 @@ Your password must:
 
 |Targobank|
 
+
 `T-Mobile <https://account.t-mobile.com/oauth2/v1/changePassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 We prefer to not tell you which characters you can use up front.
 
 |T-Mobile|
 
+
 `Taiwan Pingtung University <https://webap.nptu.edu.tw/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must:
 
@@ -1568,8 +1714,9 @@ Password must:
 
 |NPTU|
 
+
 `Techcombank <https://ib.techcombank.com.vn/servlet/BrowserServlet>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must:
 
@@ -1583,8 +1730,9 @@ Your password must:
 
 |Techcombank|
 
+
 `Telekom/T-Systems MyWorkplace <https://www.websso.t-systems.com/MyWorkplace/General/TSIPageContainer.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Telekom's MyWorkplace is a Single Sign On / login hub for their
 Open Telekom Cloud which is basically an Amazon AWS clone. It's
@@ -1595,15 +1743,17 @@ limited to a certain set.
 
 |MyWorkplace|
 
+
 `Thames Water <https://www.thameswater.co.uk/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Can only use the "special" characters on that very limited list, excluding symbols so exotic as an underscore, even. This is despite their own strength checker saying the password is strong.
 
 |ThamesWater|
 
+
 `Three <https://www.three.co.uk>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be at least 7 characters long.
 The maximum length is inconsistent, however: when changing password, the maximum length is 30, but when resetting password via email link, the maximum length is 12.
@@ -1612,15 +1762,17 @@ The maximum length is inconsistent, however: when changing password, the maximum
 
 |Three-Reset|
 
+
 `Ticketmaster.de <https://www.ticketmaster.de/myAccount/editProfile>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password length is limited between 8 and 32 characters.
 
 |Ticketmaster.de|
 
+
 `Trade Me <https://www.trademe.co.nz>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Won't allow spaces or single quotes. Maybe other characters as well -
 they do not say up front - but the password they accepted contained lots
@@ -1628,8 +1780,9 @@ of other special characters.
 
 |TradeMe|
 
+
 `TreasuryDirect <https://www.treasurydirect.gov/RS/UN-Display.do>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Will allow most passwords longer than 8 characters. Doesn't tell you there is a
 maximum length of 16 characters. Then forces you to type it with an on-screen keyboard
@@ -1639,31 +1792,35 @@ with no capital letters.
 
 |Treasury2|
 
+
 `TwinSpires <https://www.twinspires.com/account/register>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You can gamble on our site. We'll keep your money secure with a 12 character password!
 
 |TwinSpires|
 
+
 `Ubisoft <https://account.ubisoft.com/en-GB/action/change-password>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Only tells you the rules after submitting and clicking a link to a pop
 up window.
 
 |Ubisoft|
 
+
 `Unicaja <https://areaprivada.unicajabanco.es/PortalServlet?pag=1533643502465&np=S>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Username is your national Spanish ID (easy to find).
 Your password must be 6 characters long. You can't type, only select characters from the virtual keyboard
 
 |Unicaja|
 
+
 `United Parcel Service of America <https://www.ups.com/doapp/signup>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must:
 
@@ -1678,22 +1835,25 @@ Your password must:
 
 |United Parcel Service of America|
 
+
 `United States Postal Service <https://reg.usps.com/entreg/secure/ChangePasswordAction_input>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Pick from an arbitrary list of symbols, and no repeating characters.
 
 |United States Postal Service|
 
+
 `University of California San Diego <https://www.ucsd.edu>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords must be between 8 and **11** characters long!
 
 |University of California San Diego|
 
+
 `University of Texas at Austin <http://www.utdirect.utexas.edu/utdirect/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Because of the last two rules, which ban dictionary words and any
 variants using symbol substitutions, *neither* of the passwords
@@ -1701,8 +1861,9 @@ presented in the `xkcd comic <https://xkcd.com/936/>`__ are allowed.
 
 |University of Texas as Austin|
 
+
 `University of Western Australia (Pheme) <https://www.pheme.uwa.edu.au/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Passwords:
 
@@ -1732,8 +1893,9 @@ Passwords must be changed every 6 months.
 
 |University of Western Australia Pheme inspector|
 
+
 `University of Windsor <https://uwindsor.teamdynamix.com/TDClient/KB/ArticleDet?ID=46793>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The password policy applies to alumni as well. Must be at least 10
 characters long, with at least 1 upper case and 1 lower case
@@ -1742,46 +1904,52 @@ expires every 120 days, and you can't reuse an old one.
 
 |University of Windsor|
 
+
 `USAA Bank <https://www.usaa.com/inet/pages/security_take_steps_protect_logon>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password cannot be longer than 12 characters but they don't tell you that until after you try a new password. To make up for this fact they've added dubious additional security features on top of this weak foundation.
 
 
 |USAA|
 
+
 `URSSAF (French employers tax collection service) <https://www.autoentrepreneur.urssaf.fr>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 When setting a new password:
 Password must be exactly 8 characters, at least 1 letter, at least 1 number, but no special characters.
 
 
 |URSSAF|
 
+
 `Vancity Credit Union <https://support.vancity.com/17-forget-pac/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Personal Access Code (or PAC–they are too ashamed to call it a password), must be between 5 to 8 digits and cannot start with '0'. (no letters or symbols)
 
 |Vancity Credit Union|
 
+
 `Very.co.uk <https://www.very.co.uk/account/myaccount/changePassword.page>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password field allows *only* the listed Special Characters ($ . , ! % ^ \*).
 You're also forced to use both upper, and lower letters, as well as a number.
 
 |Very|
 
+
 `Vietnam Airlines <https://www.vietnamairlines.com/lotusmiles/enroll-new>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 ``[[:alnum:]]{6,8}``
 
 |Vietnam Airlines|
 
+
 `Vio Bank <https://www.viobank.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 The password requirement is not even fully enumerated. Upon inspection of the source code, the following lines were found, hidden by javascript: "Must include at least %MINSPECIAL of the following characters:-.~!@#&_{}|:$%^*()=[];?/+"
 
@@ -1791,8 +1959,9 @@ It took under 5 minutes to find the bug after looking at the source for the firs
 
 |Viobank|
 
+
 `Virgin Media <https://my.virginmedia.com/forgot-details/reset>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password needs to be between 8 and 10 characters long, with no
 spaces, and must contain only numbers and letters. The first character
@@ -1808,15 +1977,17 @@ with helpful hints after JS validation.
 
 |Virgin Media Invalid|
 
+
 `Virgin Mobile <https://myaccount.virginmobileusa.com/primary/my-account-settings-change-pin>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 You can only use PIN as your password.
 
 |Virgin Mobile|
 
+
 `Virgin Trains <https://www.buytickets.virgintrains.co.uk/buytickets/updatepersonaldetails.aspx#customerDetails>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password needs to be between 8 and 10 characters long. Previously
 this would silently truncate the password without warning, causing
@@ -1824,15 +1995,17 @@ confusion when the password wouldn't work.
 
 |Virgin Trains|
 
+
 `Walmart <https://www.walmart.com/account/signup>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password length is limited between 6 and 12 characters.
 
 |Wageworks|
 
+
 `Wageworks <https://participant.wageworks.com/Home.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 In addition to the following rules regarding passwords...
 
@@ -1846,8 +2019,9 @@ Ok. _Password21!_, it is.
 
 |Walmart|
 
+
 `Wageworks <https://participant.wageworks.com/Home.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 In addition to the following rules regarding passwords...
 
@@ -1861,50 +2035,57 @@ Ok. Password21!, it is.
 
 |Wageworks|
 
+
 `Waze <https://www.waze.com/forgot_password>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 After you request a password reset and you receive an email with instructions and link to reset your password, you are presented with this password reset form. Your password length is limited between 8 and 16 characters. Additionally the form breaks with an error if you use any special characters. The form does not mention anything about special characters. Waze is owned by Google.
 
 |Waze|
 
+
 `WeatherBug <https://www.weatherbug.com>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Maximum 16 characters.
 
 |WeatherBug|
 
+
 `Wells Fargo <https://oam.wellsfargo.com/oam/access/receiver?dest=MODIFY_PASSWORD>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must be between 6 and 14 characters.
 
 |Wells Fargo|
 
+
 `WellStar MyChart <https://mychart.wellstar.org/mychart/accesscheck.asp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password must be between 8 and 20 characters.
 
 |WellStar MyChart|
 
+
 `Westpac Live Online Banking <https://banking.westpac.com.au/secure/banking/administration/changepassword>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 6 non-case sensitive characters [exactly].  no blanks, spaces or special characters.
 
 |Westpac Live Online Banking|
 
+
 `Williams-Sonoma <https://secure.williams-sonoma.com/account/updatepassword.html>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 25 maximum characters and disallowing some specials.
 
 |Williams-Sonoma|
 
+
 `Wells Fargo Identity Theft Protection <https://enhanced.wellsfargoprotection.com/secure/MyProfile.aspx>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Your password on an Identity Theft Protection service is limited to
 between 8 and 20 characters. Your username is allowed to be longer than
@@ -1913,15 +2094,16 @@ your password.
 |Wells Fargo Identity Theft Protection|
 
 Xfinity Modem
-~~~~~~~~~~~~~~
+~~~~
 
 Only letters and numbers are valid. No spaces or special characters.
 Seen on model TG3482G. ARRIS Group, Inc. Firmware: TG3482PC2_3.5p17s1_PROD_sey
 
 |Xfinity Modem|
 
+
 `Zurich <https://www.zurichlife.ie/bgsi/log_on/password.jsp>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~
 
 Password must be EXACTLY 8 characters long.
 Alpha numeric characters ONLY.


### PR DESCRIPTION
Having the entries separated by 2 empty lines makes it easier for rst newcomers to find their way through the file.  It also fixes the entry for Nectar API, which previously was not recognized as a heading.

To normalize the empty lines between the entries:

~~~text
replace: ([^\n])\n*(`.*`__\n~~~~)
with: $1\n\n\n$2
~~~

To normalize the length of the lines below the headings:

~~~shell
awk '
  BEGIN { h = "~~~~~~~~~~"; h = h h h h h h h h h h }
  /^~~~~/ { $0 = substr(h, 1, length(prev)) }
  {prev = $0}
  { print }
' < README.rst > README.rst.tmp
mv README.rst.tmp README.rst
~~~