### PR TITLE
Add simple cache busting for Cloudflare

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,7 +2,6 @@ const esbuild = require("esbuild");
 const htmlmin = require("html-minifier");
 const md = require("markdown-it")();
 const Image = require("@11ty/eleventy-img");
-const fs = require("fs");
 
 async function imageShortcode(
   src,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ const esbuild = require("esbuild");
 const htmlmin = require("html-minifier");
 const md = require("markdown-it")();
 const Image = require("@11ty/eleventy-img");
+const fs = require("fs");
 
 async function imageShortcode(
   src,
@@ -43,13 +44,18 @@ module.exports = (eleventyConfig) => {
     });
   });
 
-  eleventyConfig.addPassthroughCopy("src/static");
+  eleventyConfig.addPassthroughCopy("src/static/img");
   eleventyConfig.addPassthroughCopy("src/screenshots");
 
   eleventyConfig.addAsyncShortcode("image", imageShortcode);
 
   eleventyConfig.addFilter("markdownIt", function (value) {
     return md.render(value);
+  });
+
+  eleventyConfig.addFilter("bustCache", (url) => {
+    const buildEpoch = Date.now();
+    return `${url}?${buildEpoch}`;
   });
 
   eleventyConfig.addTransform("htmlmin", function (content) {

--- a/src/_includes/default.njk
+++ b/src/_includes/default.njk
@@ -9,10 +9,10 @@ title: Dumb Password Rules
     {% include "ga.njk" %}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="/static/img/favicon.ico">
+    <link rel="icon" href="{{ "/static/img/favicon.ico" | bustCache }}">
     <title>{{ page_name or title }}</title>
     {% include "meta.njk" %}
-    <link rel="stylesheet" href="/static/styles/tailwind.css" type="text/css" />
+    <link rel="stylesheet" href="{{ "/static/styles/tailwind.css" | bustCache }}" type="text/css" />
 </head>
 
 <body class="h-full">
@@ -29,7 +29,7 @@ title: Dumb Password Rules
         </div>
     </div>
     {% include "footer.njk" %}
-    <script src="/static/js/bundle.js" type="text/javascript"></script>
+    <script src="{{ "/static/js/bundle.js" | bustCache }}" type="text/javascript"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 </body>
 

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -8,10 +8,10 @@ permalink: "/"
         {% include "ga.njk" %}
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="icon" href="/static/img/favicon.ico">
+        <link rel="icon" href="{{ "/static/img/favicon.ico" | bustCache }}">
         <title>Dumb Password Rules</title>
         {% include "meta.njk" %}
-        <link rel="stylesheet" href="/static/styles/tailwind.css" type="text/css" />
+        <link rel="stylesheet" href="{{ "/static/styles/tailwind.css" | bustCache }}" type="text/css" />
     </head>
     <body class="h-full">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,14 @@
 {
-  "trailingSlash": true
+  "trailingSlash": true,
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=14400, must-revalidate"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Add simple cache busting strategy for Cloudflare.

- Add build epoch time for a query parameter for assets
	- Everything else in the static directory should be good without, since most are sharp generated images 	
	- Very naive cache busting, but it'll work for now
- Set Vercel cache control headers on everything in `/static` otherwise Cloudflare seems to only want to revalidate and never returns a `HIT` status in the `cf-cache` header
- No need to pass through anything but the `img` directory in config