### PR TITLE
Update workflow cron schedule

### DIFF
--- a/.github/workflows/toot_a_dumbpassword_rule.yml
+++ b/.github/workflows/toot_a_dumbpassword_rule.yml
@@ -2,7 +2,7 @@ name: Toot a dumb password rule
 
 on:
   schedule:
-    - cron: "0 2,14 * * *"
+    - cron: "37 2,14 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Putting the time at the top of hour with a zillion other GitHub Actions can cause delays. This last one ran 24 minutes after the scheduled time: https://github.com/duffn/dumb-password-rules/actions/runs/4209161422

Try putting it at an odd time to perhaps get it to run nearer the scheduled time.