### PR TITLE
Fix too long bot toot

### DIFF
--- a/.github/bot/index.js
+++ b/.github/bot/index.js
@@ -23,10 +23,17 @@ function text() {
     decamelize: false,
   });
 
+  let description;
+  if (yaml.description.length >= 400) {
+    description = `${yaml.description.slice(0, 397)}...`;
+  } else {
+    description = yaml.description;
+  }
+
   return `This dumb password rule is from ${yaml.name}.
-  
-${yaml.description}
-  
+
+${description}
+
 https://dumbpasswordrules.com/sites/${slug}/`;
 }
 


### PR DESCRIPTION
A very long description text can result in an error.

```
MastoHttpUnprocessableEntityError: Validation failed: Text character limit of 500 exceeded
```