### PR TITLE
Run Toot only on main repository

### DIFF
--- a/.github/workflows/toot_a_dumbpassword_rule.yml
+++ b/.github/workflows/toot_a_dumbpassword_rule.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Toot a dumb password rule
+    if: ${{ github.repository == 'duffn/dumb-password-rules' }}
     defaults:
       run:
         working-directory: .github/bot


### PR DESCRIPTION
As many people will fork this repository, Actions will be enabled by default, causing this to failure.
Adding a rule to execute only in this (main) repository.