### PR TITLE
Replace "dumb" with "bad" in prose/json; keep URLs the same

### DIFF
--- a/.github/bot/README.MD
+++ b/.github/bot/README.MD
@@ -1,4 +1,4 @@
-# dumb-password-rules-bot
+# bad-password-rules-bot
 
 A bot that toots random rules at https://botsin.space/@dumbpasswordrules.
 

--- a/.github/bot/index.js
+++ b/.github/bot/index.js
@@ -32,13 +32,13 @@ function text() {
 
   console.log(`Retrieved file for ${yaml.name}.`);
 
-  return `This dumb password rule is from ${yaml.name}.
+  return `This bad password rule is from ${yaml.name}.
 
 ${description}
 
 https://dumbpasswordrules.com/sites/${slug}/
 
-#password #passwords #infosec #cybersecurity #dumbpasswordrules`;
+#password #passwords #infosec #cybersecurity #badpasswordrules`;
 }
 
 async function postSite() {

--- a/.github/bot/package-lock.json
+++ b/.github/bot/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dumb-password-rules-bot",
+  "name": "bad-password-rules-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dumb-password-rules-bot",
+      "name": "bad-password-rules-bot",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/.github/bot/package.json
+++ b/.github/bot/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dumb-password-rules-bot",
+  "name": "bad-password-rules-bot",
   "private": "true",
   "version": "1.0.0",
-  "description": "A compilation of sites with dumb password rules - the bot version.",
+  "description": "A compilation of sites with bad password rules - the bot version.",
   "type": "module",
   "scripts": {
     "toot": "node index.js"

--- a/.github/workflows/toot_a_dumbpassword_rule.yml
+++ b/.github/workflows/toot_a_dumbpassword_rule.yml
@@ -1,4 +1,4 @@
-name: Toot a dumb password rule
+name: Toot a bad password rule
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Toot a dumb password rule
+    name: Toot a bad password rule
     if: ${{ github.repository == 'duffn/dumb-password-rules' }}
     defaults:
       run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to the https://dumbpasswordrules.com si
 
 ## New sites
 
-If you're interested in adding a new site with a dumb password rule, you can follow the setup steps below or optionally you can simply create a new YAML file, open a PR, and Vercel will build a preview environment for your changes.
+If you're interested in adding a new site with a bad password rule, you can follow the setup steps below or optionally you can simply create a new YAML file, open a PR, and Vercel will build a preview environment for your changes.
 
 - Add a new YAML file for your entry in the `_data/sites` directory.
 
@@ -12,14 +12,14 @@ If you're interested in adding a new site with a dumb password rule, you can fol
 
   - A name.
     - This must be unique amongst all the entries.
-  - A clean description about the dumb password rule.
+  - A clean description about the bad password rule.
     - The `description` of an entry can be any valid markdown.
     - Sarcasm encouraged.
   - At least one screenshot.
 
 - Entries can optionally include:
 
-  - A URL to the offending dumb rule.
+  - A URL to the offending bad rule.
 
 - Follow the format of the other entries.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dumb Password Rules
+# Bad Password Rules
 
 https://dumbpasswordrules.com
 
@@ -10,7 +10,7 @@ A compilation of sites with dumb password rules.
 
 ### New sites
 
-Feel free to submit a pull request with dumb password rules you've encountered!
+Feel free to submit a pull request with bad password rules you've encountered!
 
 You can find more details in the [contributing doc](CONTRIBUTING.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dumb-password-rules",
+  "name": "bad-password-rules",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dumb-password-rules",
+      "name": "bad-password-rules",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dumb-password-rules",
+  "name": "bad-password-rules",
   "private": "true",
   "version": "1.0.0",
-  "description": "A compilation of sites with dumb password rules.",
+  "description": "A compilation of sites with bad password rules.",
   "scripts": {
     "serve": "concurrently \"./node_modules/.bin/eleventy --serve\" \"./node_modules/.bin/tailwindcss -i ./src/static/styles/tailwind.css -o ./_site/static/styles/tailwind.css --postcss --watch\"",
     "build": "./node_modules/.bin/eleventy && ./node_modules/.bin/tailwindcss -i ./src/static/styles/tailwind.css -o ./_site/static/styles/tailwind.css --postcss --minify"

--- a/src/_data/sites/coppell-tx-water-utility.yaml
+++ b/src/_data/sites/coppell-tx-water-utility.yaml
@@ -1,5 +1,5 @@
 description: |-
-  Local Utility with a password restriction of 30 characters. Better than some for sure, but still dumb.
+  Local Utility with a password restriction of 30 characters. Better than some for sure, but still bad.
 images:
   - coppell_tx_water_utility.png
 name: Coppell, TX - Water Utility

--- a/src/_data/sites/dell.yaml
+++ b/src/_data/sites/dell.yaml
@@ -1,9 +1,9 @@
 description: |-
   Okay at least 6, that's alright I guess.
 
-  Oh at least one number and one letter, bit dumb but hey not that dumb.
+  Oh at least one number and one letter, bit bad but hey not that bad.
 
-  But hiding the fact that it has a max of 20, now THAT is dumb!
+  But hiding the fact that it has a max of 20, now THAT is bad!
 images:
   - dell.png
 name: Dell

--- a/src/_data/sites/ibm-tsoe-logon-terminal.yaml
+++ b/src/_data/sites/ibm-tsoe-logon-terminal.yaml
@@ -1,5 +1,5 @@
 description: |-
-  It might not be a web site, but that does not make it less dumb.
+  It might not be a web site, but that does not make it less bad.
   Since many don't know about IBM mainframes, it seems they don't think you need to up the policies.
 
   Default old password policy is: 6-8 characters long, A-Z, 0-9

--- a/src/_data/sites/ikea.yaml
+++ b/src/_data/sites/ikea.yaml
@@ -1,5 +1,5 @@
 description: |-
-  Dumb restriction for consecutive similar characters. Wonder if someone got more that 2 identical characters in their name then
+  Bad restriction for consecutive similar characters. Wonder if someone got more that 2 identical characters in their name then
   it won't allow you to even use name in password.
 
   Password must contain:

--- a/src/_data/sites/interactive-brokers.yaml
+++ b/src/_data/sites/interactive-brokers.yaml
@@ -1,5 +1,5 @@
 description: |-
-  Usual dumb password restrictions, but this one has incredibly dumb **username**
+  Usual bad password restrictions, but this one has incredibly bad **username**
   restrictions too:
 
   **Username:**

--- a/src/_data/sites/itau.yaml
+++ b/src/_data/sites/itau.yaml
@@ -7,7 +7,7 @@ description: |-
   - You can't repeat the same character more than two times in a row.
   - Avoid using basic character sequences such as "qwerty", "asdf", "1234" or "9876".
 
-  _Just in case, that's eight characters. Not seven, not nine. That's dumb and insecure enough... What they don't tell you is that the passwords are are actually **not** case sensitive._
+  _Just in case, that's eight characters. Not seven, not nine. That's bad and insecure enough... What they don't tell you is that the passwords are are actually **not** case sensitive._
 images:
   - itau.png
 name: Itaú Bank

--- a/src/_data/sites/izly-by-crous.yaml
+++ b/src/_data/sites/izly-by-crous.yaml
@@ -1,7 +1,7 @@
 description:
   "Izly by Crous is an **imposed** French payment service for the\nuniversity.\
   \ You can't pay your daily meal without that because yeah you\nknow cash is an ancient\
-  \ dumb thing.\n\nYour username is firstname.lastname@youruniversity.fr or your phone\n\
+  \ bad thing.\n\nYour username is firstname.lastname@youruniversity.fr or your phone\n\
   number. We only allow you a fixed 6 numbers password. Oh yeah we also\nblock your\
   \ account after three failed attempts. How convenient when the\nonly thing you need\
   \ to know is the name of someone and where they study.\nHow convenient indeed.\n\n\

--- a/src/_data/sites/jitterbit.yaml
+++ b/src/_data/sites/jitterbit.yaml
@@ -1,5 +1,5 @@
 description: |-
-  While not the dumbest password rule, still dumb.
+  While not the worst password rule, still bad.
 
   Password must have a length of at least eight characters and contain
   at least one: number, special char `!#$%-_=+<>`, capital letter,

--- a/src/_includes/default.njk
+++ b/src/_includes/default.njk
@@ -1,5 +1,5 @@
 ---
-title: Dumb Password Rules
+title: Bad Password Rules
 ---
 
 <!doctype html>

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -6,7 +6,7 @@
         </div>
         <div class="mt-8 md:order-1 md:mt-0">
             <p class="text-center text-xs leading-5 text-gray-500">
-                <a class="underline text-red-600" href="https://dumbpasswordrules.com">Dumb Password Rules</a> is built
+                <a class="underline text-red-600" href="https://dumbpasswordrules.com">Bad Password Rules</a> is built
                 by <a class="underline text-red-600" href="https://github.com/duffn">duffn</a> and many amazing
                 <a class="underline text-red-600"
                     href="https://github.com/duffn/dumb-password-rules/graphs/contributors">contributors</a>.

--- a/src/_includes/meta.njk
+++ b/src/_includes/meta.njk
@@ -1,15 +1,15 @@
 <meta name="generator" content="Eleventy">
-<meta name="description" content="{{ description or "A compilation of sites with dumb password rules." }}">
+<meta name="description" content="{{ description or "A compilation of sites with bad password rules." }}">
 
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ meta_url or "https://dumbpasswordrules.com" }}">
 <meta property="og:image" content="{{ meta_image or "https://dumbpasswordrules.com/static/img/logo-large.png" }}" />
-<meta property="og:title" content="{{ page_name or "Dumb Password Rules" }}">
-<meta property="og:description" content="{{ description or "A compilation of sites with dumb password rules." }}">
+<meta property="og:title" content="{{ page_name or "Bad Password Rules" }}">
+<meta property="og:description" content="{{ description or "A compilation of sites with bad password rules." }}">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:domain" content="dumbpasswordrules.com">
 <meta name="twitter:url" content="{{ meta_url or "https://dumbpasswordrules.com" }}">
 <meta name="twitter:image" content="{{ meta_image or "https://dumbpasswordrules.com/static/img/logo-large.png" }}" />
-<meta name="twitter:title" content="{{ page_name or "Dumb Password Rules"  }}">
-<meta name="twitter:description" content="{{ description or "A compilation of sites with dumb password rules." }}">
+<meta name="twitter:title" content="{{ page_name or "Bad Password Rules"  }}">
+<meta name="twitter:description" content="{{ description or "A compilation of sites with bad password rules." }}">

--- a/src/_includes/nav.njk
+++ b/src/_includes/nav.njk
@@ -4,8 +4,8 @@
             <div class="flex">
                 <div class="flex flex-shrink-0 items-center">
                     <a href="/">
-                        <img class="block h-8 w-auto lg:hidden" src="/static/img/logo-med.png" alt="Dumb Password Rules">
-                        <img class="hidden h-8 w-auto lg:block" src="/static/img/logo-med.png" alt="Dumb Password Rules">
+                        <img class="block h-8 w-auto lg:hidden" src="/static/img/logo-med.png" alt="Bad Password Rules">
+                        <img class="hidden h-8 w-auto lg:block" src="/static/img/logo-med.png" alt="Bad Password Rules">
                     </a>
                 </div>
                 <div class="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">

--- a/src/pages/404.njk
+++ b/src/pages/404.njk
@@ -10,7 +10,7 @@ eleventyExcludeFromCollections: true
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="{{ " /static/img/favicon.ico" | bustCache }}">
-    <title>Dumb Password Rules</title>
+    <title>Bad Password Rules</title>
     {% include "meta.njk" %}
     <link rel="stylesheet" href="{{ " /static/styles/tailwind.css" | bustCache }}" type="text/css" />
 </head>
@@ -18,7 +18,7 @@ eleventyExcludeFromCollections: true
 <body class="h-full">
     <main class="grid min-h-full place-items-center bg-white py-24 px-6 sm:py-32 lg:px-8">
         <div class="text-center">
-            <img class="mx-auto h-10 w-auto sm:h-12 mb-20" src="/static/img/logo-med.png" alt="Dumb Password Rules">
+            <img class="mx-auto h-10 w-auto sm:h-12 mb-20" src="/static/img/logo-med.png" alt="Bad Password Rules">
             <p class="text-base font-semibold text-red-600">404</p>
             <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found</h1>
             <p class="mt-6 text-base leading-7 text-gray-600">Sorry, we couldn't find the page you're looking for.</p>

--- a/src/pages/about.njk
+++ b/src/pages/about.njk
@@ -5,7 +5,7 @@ permalink: "/about/"
 
 <div class="bg-white py-24 px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
-        <p class="text-lg font-semibold leading-8 tracking-tight text-red-600">Dumb Password Rules</p>
+        <p class="text-lg font-semibold leading-8 tracking-tight text-red-600">Bad Password Rules</p>
         <h2 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">About</h2>
     </div>
     <div class="divide-y divide-gray-900/10">
@@ -14,8 +14,8 @@ permalink: "/about/"
                 <dt class="text-base font-semibold leading-7 text-gray-900 lg:col-span-5">Why does this exist?</dt>
                 <dd class="mt-4 lg:col-span-7 lg:mt-0">
                     <p class="text-base leading-7 text-gray-600">
-                        I get very annoyed when I encounter a dumb password rule in the wild. One day, I had enough and
-                        wanted to let everybody know how dumb these rules are.
+                        I get very annoyed when I encounter a bad password rule in the wild. One day, I had enough and
+                        wanted to let everybody know how bad these rules are.
                     </p>
                 </dd>
             </div>
@@ -40,7 +40,7 @@ permalink: "/about/"
                 </dd>
             </div>
             <div class="pt-8 lg:grid lg:grid-cols-12 lg:gap-8">
-                <dt class="text-base font-semibold leading-7 text-gray-900 lg:col-span-5">What makes a dumb password?</dt>
+                <dt class="text-base font-semibold leading-7 text-gray-900 lg:col-span-5">What makes a bad password?</dt>
                 <dd class="mt-4 lg:col-span-7 lg:mt-0">
                     <p class="text-base leading-7 text-gray-600">
                         You probably know it when you see it. "Maximum 17 characters, must start with a 7, no ~ allowed." If you aren't sure, open a new <a
@@ -54,7 +54,7 @@ permalink: "/about/"
             </div>
             <div class="pt-8 lg:grid lg:grid-cols-12 lg:gap-8">
                 <dt class="text-base font-semibold leading-7 text-gray-900 lg:col-span-5">I found a password rule that I
-                    think is dumb. Can I add it to this list?</dt>
+                    think is bad. Can I add it to this list?</dt>
                 <dd class="mt-4 lg:col-span-7 lg:mt-0">
                     <p class="text-base leading-7 text-gray-600">
                         New contributions are always welcome! Please add your entry on <a
@@ -70,7 +70,7 @@ permalink: "/about/"
                 <dt class="text-base font-semibold leading-7 text-gray-900 lg:col-span-5">My company is on this list. How can I have us removed?</dt>
                 <dd class="mt-4 lg:col-span-7 lg:mt-0">
                     <p class="text-base leading-7 text-gray-600">
-                        If you've fixed your dumb password rule, awesome! I'll happily remove entries that have been corrected. 
+                        If you've fixed your bad password rule, awesome! I'll happily remove entries that have been corrected. 
                         Please open a pull request to have your entry removed on <a
                             class="underline text-red-600"
                             href="https://github.com/duffn/dumb-password-rules">GitHub</a>.

--- a/src/pages/index.njk
+++ b/src/pages/index.njk
@@ -9,7 +9,7 @@ permalink: "/"
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="icon" href="{{ "/static/img/favicon.ico" | bustCache }}">
-        <title>Dumb Password Rules</title>
+        <title>Bad Password Rules</title>
         {% include "meta.njk" %}
         <link rel="stylesheet" href="{{ "/static/styles/tailwind.css" | bustCache }}" type="text/css" />
     </head>
@@ -19,14 +19,14 @@ permalink: "/"
                 <div class="mx-auto max-w-7xl lg:grid lg:grid-cols-12 lg:gap-x-8 lg:px-8">
                     <div class="px-6 pt-10 pb-24 sm:pb-32 lg:col-span-7 lg:px-0 lg:pt-48 lg:pb-56 xl:col-span-6">
                         <div class="mx-auto max-w-2xl lg:mx-0">
-                            <img class="h-11" src="/static/img/logo-med.png" alt="Dumb Password Rules">
+                            <img class="h-11" src="/static/img/logo-med.png" alt="Bad Password Rules">
                             <div class="hidden sm:mt-32 sm:flex lg:mt-16">
                                 <div class="relative rounded-full py-1 px-3 text-sm leading-6 text-gray-500 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
-                                    Know a site with dumb password rules? <a href="https://github.com/duffn/dumb-password-rules" class="whitespace-nowrap font-semibold text-red-600"><span class="absolute inset-0" aria-hidden="true"></span>Contribute <span aria-hidden="true">→</span></a>
+                                    Know a site with bad password rules? <a href="https://github.com/duffn/dumb-password-rules" class="whitespace-nowrap font-semibold text-red-600"><span class="absolute inset-0" aria-hidden="true"></span>Contribute <span aria-hidden="true">→</span></a>
                                 </div>
                             </div>
-                            <h1 class="mt-24 text-4xl font-bold tracking-tight text-gray-900 sm:mt-10 sm:text-6xl">Dumb Password Rules</h1>
-                            <p class="mt-6 text-lg leading-8 text-gray-600">A compilation of {{ sites | length }} sites with dumb password rules.</p>
+                            <h1 class="mt-24 text-4xl font-bold tracking-tight text-gray-900 sm:mt-10 sm:text-6xl">Bad Password Rules</h1>
+                            <p class="mt-6 text-lg leading-8 text-gray-600">A compilation of {{ sites | length }} sites with bad password rules.</p>
                             <div class="mt-10 flex items-center gap-x-6">
                                 <a href="/sites/" class="rounded-md bg-red-600 px-3.5 py-1.5 text-base font-semibold leading-7 text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600">View sites</a>
                                 <a href="https://github.com/duffn/dumb-password-rules" class="text-base font-semibold leading-7 text-gray-900">Contribute <span aria-hidden="true">→</span></a>

--- a/src/pages/sites/slug.njk
+++ b/src/pages/sites/slug.njk
@@ -7,7 +7,7 @@ pagination:
     addAllPagesToCollections: true
 permalink: "/sites/{{ site.name | slugify }}/"
 eleventyComputed:
-    page_name: "{{ site.name }} - Dumb Password Rules"
+    page_name: "{{ site.name }} - Bad Password Rules"
     meta_url: "{{ siteMeta.url }}/sites/{{ site.name | slugify }}/"
     meta_image: "{{ siteMeta.url }}/screenshots/{{ site.images[0] }}"
     description: "{{ site.description | striptags(true) | escape }}"
@@ -29,7 +29,7 @@ eleventyComputed:
             {% for image in site.images %}
                 <div class="mt-10">
                     <a href="/screenshots/{{ image }}">
-                        {% image "./src/screenshots/" + image , "w-3/4", site.name + " dumb password rule screenshot" %}
+                        {% image "./src/screenshots/" + image , "w-3/4", site.name + " bad password rule screenshot" %}
                     </a>
                 </div>
             {% endfor %}


### PR DESCRIPTION
Partly addresses #500: this PR replaces all the free text usages of "dumb" with "bad". However I haven't changed URLs (including Mastodon and GitHub URLs).

Let me know, I'm happy to make this an all-in-one PR that assumes all the following have been migrated:
- [ ] the main website URL
- [ ] this repo
- [ ] the Mastodon bot

Again, many thanks for your support in this!