### PR TITLE
feat: update bot URL

### DIFF
--- a/.github/bot/index.js
+++ b/.github/bot/index.js
@@ -44,7 +44,7 @@ https://dumbpasswordrules.com/sites/${slug}/
 async function postSite() {
   try {
     const masto = await login({
-      url: "https://botsin.space",
+      url: process.env.MASTODON_URL,
       accessToken: process.env.MASTODON_API_ACCESS_TOKEN,
     });
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ npx http-server ./_site # Or `python -m http.server --directory _site` or any ot
 
 There's now a bot that will toot random rules periodically! You can take a look in the `.github/bot` directory.
 
-You'll first need a bot on the https://botsin.space instance in order to run this code.
+You'll first need a bot on the https://infosec.exchange instance in order to run this code.
 
 - Have [Node.js 18+](https://nodejs.org/en/) installed.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://dumbpasswordrules.com
 
 A compilation of sites with dumb password rules.
 
-⭐️ Now with a bot that periodically toots random rules! https://botsin.space/@dumbpasswordrules
+⭐️ Now with a bot that periodically toots random rules! https://infosec.exchange/@dumbpasswordrules
 
 ## Contributing
 

--- a/src/pages/about.njk
+++ b/src/pages/about.njk
@@ -35,7 +35,7 @@ permalink: "/about/"
                 <dd class="mt-4 lg:col-span-7 lg:mt-0">
                     <p class="text-base leading-7 text-gray-600">
                         There's also a <a class="underline text-red-600"
-                            href="https://botsin.space/@dumbpasswordrules">bot</a> that periodically toots random rules on Mastodon!
+                            href="https://infosec.exchange/@dumbpasswordrules">bot</a> that periodically toots random rules on Mastodon!
                     </p>
                 </dd>
             </div>


### PR DESCRIPTION
- Update the bot URL to an environment variable for easy updating. Necessary now because the botsin.space server is being deleted: https://muffinlabs.com/posts/2024/10/29/10-29-rip-botsin-space/
- And update the URL elsewhere